### PR TITLE
:bug:(models) removes username requirement for user creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+oo

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ MANAGE              = $(COMPOSE_RUN_APP) python manage.py
 MAIL_YARN           = $(COMPOSE_RUN) -w /app/src/mail node yarn
 TSCLIENT_YARN       = $(COMPOSE_RUN) -w /app/src/tsclient node yarn
 
+# -- Demo app superuser
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_EMAIL=django@example.com
+RANDOM_UUID=$(shell uuidgen)
+
 # ==============================================================================
 # RULES
 
@@ -73,6 +78,7 @@ bootstrap: \
 	env.d/development/postgresql \
 	build \
 	run \
+	makemigrations \
 	migrate \
 	i18n-compile \
 	mails-install \
@@ -169,7 +175,7 @@ migrate:  ## run django migrations for the people project.
 
 superuser: ## Create an admin superuser with password "admin"
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"
-	@$(MANAGE) createsuperuser --username admin --email admin@example.com --no-input
+	@$(MANAGE) createsuperuser  --id $(RANDOM_UUID) --no-input
 .PHONY: superuser
 
 back-i18n-compile: ## compile the gettext files

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Compose](https://docs.docker.com/compose/install) installed on your laptop:
 $ docker -v
   Docker version 20.10.2, build 2291f61
 
-$ docker compose -v
-  docker compose version 1.27.4, build 40524192
+$ docker compose version
+  Docker Compose version v1.27.4
 ```
 
 > ⚠️ You may need to run the following commands with `sudo` but this can be


### PR DESCRIPTION
## Purpose

User creation is not allowed for lack of a username, required by django. I'm trying to fix that so we can use uuid as primary key instead.

## Proposal

Description...

- [x] fixing migrations issue
- [x] fixing username / id issue upon creating superuser or demo app

# 🏕 Amélioration continue

Cannot login to admin :
![Capture d’écran du 2024-01-05 13-37-55](https://github.com/numerique-gouv/people/assets/30848497/d970ed63-459e-4ab6-ae92-c00d461fa464)

Plutôt que de débugger ça avec simplement l'uuid, je propose qu'on ajoute au Dockerfile un petit fournisseur d'identité OIDC tout simple, comme ça on sera déjà en situation pour ProConnect.
