### PR TITLE
👷(ci) Configure workflows to use sops secrets instead of github secrets

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -272,13 +272,18 @@ jobs:
         run: pip install --user .[dev]
       - name: Generate the translation base file
         run: ~/.local/bin/django-admin makemessages --keep-pot --all
+      - name: Load sops secrets
+        uses: rouja/actions-sops@main
+        with:
+          secret-file: .github/workflows/secrets.enc.env
+          age-key: ${{ secrets.SOPS_PRIVATE }}
       - name: Upload files to Crowdin
         run: |
           docker run \
           --rm \
-          -e CROWDIN_API_TOKEN=${{ secrets.CROWDIN_API_TOKEN }} \
-          -e CROWDIN_PROJECT_ID=${{ vars.CROWDIN_PROJECT_ID }} \
-          -e CROWDIN_BASE_PATH=${{ vars.CROWDIN_BASE_PATH }} \
+          -e CROWDIN_API_TOKEN=$CROWDIN_API_TOKEN \
+          -e CROWDIN_PROJECT_ID=$CROWDIN_PROJECT_ID \
+          -e CROWDIN_BASE_PATH=$CROWDIN_BASE_PATH \
           -v "${{ github.workspace }}:/app" \
           crowdin/cli:3.16.0 \
           crowdin upload sources -c /app/crowdin/config.yml
@@ -298,8 +303,13 @@ jobs:
         run: docker build -t people:${{ github.sha }} --target production .
       - name: Check built images availability
         run: docker images "people:${{ github.sha }}*"
+      - name: Load sops secrets
+        uses: rouja/actions-sops@main
+        with:
+          secret-file: .github/workflows/secrets.enc.env
+          age-key: ${{ secrets.SOPS_PRIVATE }}
       - name: Login to DockerHub
-        run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USER }}" --password-stdin
+        run: echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin
       - name: Tag images
         run: |
           DOCKER_TAG=$([[ -z "${{ github.event.ref }}" ]] && echo "${{ github.event.ref }}" || echo "${{ github.event.ref }}" | sed 's/^v//')

--- a/.github/workflows/secrets.enc.env
+++ b/.github/workflows/secrets.enc.env
@@ -1,0 +1,12 @@
+SOPS_PRIVATE=ENC[AES256_GCM,data:Dvap/lyfxBjUpazOD7+ROp2zxuoTln0vvW4MztNIOrp4Do8MzUwtrAIhf8sGON+7jBhVv5qg11cCz1Av8HphtAOhBcE3yvzhd1k=,iv:Ihv1iA8iNEjkOXI6cgIPNwsCo9mfM9QCWlJYKq9vXrA=,tag:tmv7zBVfHXXoxrsu5DT+DA==,type:str]
+CROWDIN_API_TOKEN=ENC[AES256_GCM,data:tTeYPLs6fL16YwzHW40WnoHzBP74bkIQAbJszkkg59xyre110i3HbixQG8RncHokqLlsSRir5UbinbljwBOTxJkr0aijWikakkWL3vm6Q3I=,iv:5ZI9jULthXiUYACXzCFizLoxH2NoXpJu3C0Ayzjs7R4=,tag:QJQXT03//imG+SNzuIxFXw==,type:str]
+CROWDIN_BASE_PATH=ENC[AES256_GCM,data:ZIQxj5qcdVU=,iv:p45ZL57qNQ6/ZM4eB+TtomhqZyblZnnS6yRITOl2SJg=,tag:HhXzA2XosOXVvq7hP+j0WA==,type:str]
+CROWDIN_PROJECT_ID=ENC[AES256_GCM,data:OeVXEczq,iv:xpySbY28iEIzFDxyQHmF4dm68H6yjTes04ZBFltJ9Os=,tag:/G/lpdA56hrWPaNNUEDptQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5VzdtR0FDOUJPZmQreGZX\nSGFwaEFNR2lTaURsVmFvSWRiRCtxZkk5L1RzClpmWnpBbThXMGxzZWY2UU5ycFoy\nMDcvMEdMajBlS2lPZXdMVmpDeVJuZHMKLS0tIDhlSDZzVzVFbVh2OC8zaG1Rd3RD\nbFJuWjdSKzFocDMvZnF5eEZ1U2crN1kKwZCvKYea38ZFSWokmkLFrxwIfs3WE2Op\nLZP79V1LMHp6RwRrUGh/lyixWjZQ2YbIkOoI64Xss/qwcCrAzB++fw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age15fyxdwmg5mvldtqqus87xspuws2u0cpvwheehrtvkexj4tnsqqysw6re2x
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTllEV2ROQWFwd0o3dThm\nUkdEa08rTTZIUDRHZ29kTk5MM1ZpaUtXb1RZCllQV3JjRk1vM2FHemQ0dFplMDVy\nTS9TcnR4RUV3cTVXMWtwU2ZQSkZna3cKLS0tIDNMMGp0dUpUSnRmcXh1aWxiSU9Y\nNVlFWDJZZ3dIUDVyb3J1RFBuais0aHMKXPBEHf72EhJLSGnwHNBFzsRz3ijnA9sx\ndMtdWIl0j4G2UTHey6DIS2MMDMXJUWt4VGEHNdtionfcVgl6i71ToA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age16hnlml8yv4ynwy0seer57g8qww075crd0g7nsundz3pj4wk7m3vqftszg7
+sops_lastmodified=2024-01-08T15:27:30Z
+sops_mac=ENC[AES256_GCM,data:5g9YdRzV3wqFLX7fu01CjJ4UXlFKHI/F4pICkG3DOZXkcfKY+pYMe5q5lLGGU7NL2HmSSQFa9YjMVsZFHxLNaDBECGEtU+vaBOZYjFBcfZM+nSY7/kNNSM6AUJ7nJnfr0L331lyV56aLUFiZCRWyORyNaEdFdaCHyW+v+Y+TiQI=,iv:ViKq03kTYw1gm7AVEURNA8hMBoo0qZwT9m8t7pCeP20=,tag:7dmiCu5BmN/Wwcb7GeTVsQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.8.1

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,7 @@
+creation_rules:
+  # Here we have
+  # - jacques key-id: age15fyxdwmg5mvldtqqus87xspuws2u0cpvwheehrtvkexj4tnsqqysw6re2x
+  # - github-repo key-id: age16hnlml8yv4ynwy0seer57g8qww075crd0g7nsundz3pj4wk7m3vqftszg7
+  - age:
+      age15fyxdwmg5mvldtqqus87xspuws2u0cpvwheehrtvkexj4tnsqqysw6re2x,
+      age16hnlml8yv4ynwy0seer57g8qww075crd0g7nsundz3pj4wk7m3vqftszg7

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+PRE_COMMIT_FILE="$(dirname -- "${BASH_SOURCE[0]}")/../.git/hooks/pre-commit"
+
+cat <<'EOF' >$PRE_COMMIT_FILE
+#!/bin/bash
+
+# directories containing potential secrets
+DIRS="."
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# allow to read user input, assigns stdin to keyboard
+exec </dev/tty
+
+for d in $DIRS; do
+	# find files containing secrets that should be encrypted
+	for f in $(find "${d}" -type f -regex ".*enc.*"); do
+		if ! $(grep -q "unencrypted_suffix" $f); then
+			printf '\xF0\x9F\x92\xA5 '
+			echo "File $f has non encrypted secrets!"
+			exit 1
+		fi
+	done
+done
+EOF
+
+chmod +x $PRE_COMMIT_FILE


### PR DESCRIPTION
Github secrets are difficult to maintain in time because we do not have a way to track them efficiently. So to avoid this issue, we prefer to use sops encrypted files to manage our secrets.