### PR TITLE
🔧(project) update Renovate configuration to fix match manager issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "enabled": false,
       "groupName": "ignored python dependencies",
       "matchManagers": [
-        "setup-cfg"
+        "pep621"
       ],
       "matchPackageNames": []
     },


### PR DESCRIPTION
## Purpose

Use the right Python match manager when ignoring dependencies.

## Proposal

The current Renovate configuration is using the wrong match manager, as our project utilizes `pyproject.toml` instead of `setup.cfg`. This commit corrects the configuration to ensure compatibility with our project structure.
