### PR TITLE
🐛(api) enable search on identities

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -180,8 +180,8 @@ class UserViewSet(
 
     GET /api/users/&q=query
         Return a list of users whose email matches the query. Similarity is
-        calculated using trigram similarity, allowing for partial, case
-        insensitive matches and accentuated queries.
+        calculated using trigram similarity, allowing for partial,
+        case-insensitive matches and accented queries.
     """
 
     permission_classes = [permissions.IsSelf]
@@ -203,7 +203,7 @@ class UserViewSet(
             # Search by case-insensitive and accent-insensitive trigram similarity
             if query := self.request.GET.get("q", ""):
                 similarity = TrigramSimilarity(
-                    Func("email", function="unaccent"),
+                    Func("identities__email", function="unaccent"),
                     Func(Value(query), function="unaccent"),
                 )
                 queryset = (

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1,6 +1,6 @@
 """API endpoints"""
 from django.contrib.postgres.search import TrigramSimilarity
-from django.db.models import Func, OuterRef, Q, Subquery, Value
+from django.db.models import Func, Max, OuterRef, Q, Subquery, Value
 
 from rest_framework import (
     decorators,
@@ -202,9 +202,11 @@ class UserViewSet(
 
             # Search by case-insensitive and accent-insensitive trigram similarity
             if query := self.request.GET.get("q", ""):
-                similarity = TrigramSimilarity(
-                    Func("identities__email", function="unaccent"),
-                    Func(Value(query), function="unaccent"),
+                similarity = Max(
+                    TrigramSimilarity(
+                        Func("identities__email", function="unaccent"),
+                        Func(Value(query), function="unaccent"),
+                    )
                 )
                 queryset = (
                     queryset.annotate(similarity=similarity)

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -124,10 +124,10 @@ def test_api_users_authenticated_list_multiple_identities_single_user():
     assert response.json()["results"][0]["id"] == str(dave.id)
 
 
-def test_api_users_authenticated_list_multiple_identities_best_result():
+def test_api_users_authenticated_list_multiple_identities_multiple_users():
     """
     User with multiple identities should be ranked
-    on their best matching identities.
+    on their best matching identity.
     """
     user = factories.UserFactory(email="tester@ministry.fr")
     factories.IdentityFactory(user=user, email=user.email)


### PR DESCRIPTION
## 💭 Purpose

A previous PR enabled user search using the email. After discussing models, we chose to enable research on emails provided on identities, and return linked user.

## 📝 Proposal

Description...

- [x] adapted user `get_queryset` to search among identities' emails. 
- [x] adapted tests
- [x] add a test to check user is returned once, even if their identities match several times
- [x] substituted bare status code with DRF named constants (see this [DRF page](https://www.django-rest-framework.org/api-guide/status-codes/))
