### PR TITLE
🩹(backend) enhance Django Admin for Team Slug

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -105,8 +105,8 @@ class TeamAdmin(admin.ModelAdmin):
     inlines = (TeamAccessInline,)
     list_display = (
         "name",
+        "slug",
         "created_at",
         "updated_at",
     )
-    prepopulated_fields = {"slug": ("name",)}
     search_fields = ("name",)

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -316,7 +316,7 @@ class Team(BaseModel):
     """
 
     name = models.CharField(max_length=100)
-    slug = models.SlugField(max_length=100, unique=True, null=False)
+    slug = models.SlugField(max_length=100, unique=True, null=False, editable=False)
 
     users = models.ManyToManyField(
         User,


### PR DESCRIPTION
Make Team's Slug field non-editable in the Django admin.

Avoids UX issues by preventing accidental slug overwrites during updates. The Slug is now conveniently displayed in the teams list view.

Before:


https://github.com/numerique-gouv/people/assets/45729124/d95ebdfb-b898-47bf-951d-63f239e3c9b7


After:

https://github.com/numerique-gouv/people/assets/45729124/b4299471-184e-41ce-86a8-b84f6016382c

