### PR TITLE
🥅(frontend ) page 404

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Set services env variables
         run: |
           make create-env-files
+          cat env.d/development/common.e2e.dist >> env.d/development/common
 
       - name: Build and Start Docker Servers
         env:

--- a/env.d/development/common.e2e.dist
+++ b/env.d/development/common.e2e.dist
@@ -1,0 +1,3 @@
+# For the CI job test-e2e
+SUSTAINED_THROTTLE_RATES="200/hour"
+BURST_THROTTLE_RATES="200/minute"

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -228,7 +228,18 @@ class Base(Configuration):
         "PAGE_SIZE": 20,
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
         "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-        "DEFAULT_THROTTLE_RATES": {"sustained": "150/hour", "burst": "20/minute"},
+        "DEFAULT_THROTTLE_RATES": {
+            "sustained": values.Value(
+                default="150/hour",
+                environ_name="SUSTAINED_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
+            "burst": values.Value(
+                default="20/minute",
+                environ_name="BURST_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
+        },
     }
 
     SPECTACULAR_SETTINGS = {

--- a/src/frontend/apps/desk/src/api/APIError.ts
+++ b/src/frontend/apps/desk/src/api/APIError.ts
@@ -1,0 +1,17 @@
+interface IAPIError {
+  status: number;
+  cause?: string[];
+}
+
+export class APIError extends Error implements IAPIError {
+  public status: number;
+  public cause?: string[];
+
+  constructor(message: string, { status, cause }: IAPIError) {
+    super(message);
+
+    this.name = 'APIError';
+    this.status = status;
+    this.cause = cause;
+  }
+}

--- a/src/frontend/apps/desk/src/api/index.ts
+++ b/src/frontend/apps/desk/src/api/index.ts
@@ -1,2 +1,4 @@
+export * from './APIError';
 export * from './fetchApi';
 export * from './types';
+export * from './utils';

--- a/src/frontend/apps/desk/src/api/utils.ts
+++ b/src/frontend/apps/desk/src/api/utils.ts
@@ -1,0 +1,17 @@
+export const errorCauses = async (response: Response) => {
+  const errorsBody = (await response.json()) as Record<
+    string,
+    string | string[]
+  > | null;
+
+  const causes = errorsBody
+    ? Object.entries(errorsBody)
+        .map(([, value]) => value)
+        .flat()
+    : undefined;
+
+  return {
+    status: response.status,
+    cause: causes,
+  };
+};

--- a/src/frontend/apps/desk/src/components/Text.tsx
+++ b/src/frontend/apps/desk/src/components/Text.tsx
@@ -38,6 +38,8 @@ export interface TextProps extends BoxProps {
     | '900';
 }
 
+export type TextType = ComponentPropsWithRef<typeof Text>;
+
 export const TextStyled = styled(Box)<TextProps>`
   ${({ $textAlign }) => $textAlign && `text-align: ${$textAlign};`}
   ${({ $weight }) => $weight && `font-weight: ${$weight};`}

--- a/src/frontend/apps/desk/src/components/TextErrors.tsx
+++ b/src/frontend/apps/desk/src/components/TextErrors.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+
+import { Box, Text, TextType } from '@/components';
+
+interface TextErrorsProps extends TextType {
+  causes?: string[];
+  defaultMessage?: string;
+}
+
+export const TextErrors = ({
+  causes,
+  defaultMessage,
+  ...textProps
+}: TextErrorsProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      {causes &&
+        causes.map((cause, i) => (
+          <Text
+            key={`causes-${i}`}
+            className="mt-s"
+            $theme="danger"
+            $textAlign="center"
+            {...textProps}
+          >
+            {cause}
+          </Text>
+        ))}
+
+      {!causes && (
+        <Text
+          className="mt-s"
+          $theme="danger"
+          $textAlign="center"
+          {...textProps}
+        >
+          {defaultMessage || t('Something bad happens, please retry.')}
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/src/frontend/apps/desk/src/features/teams/api/useCreateTeam.tsx
+++ b/src/frontend/apps/desk/src/features/teams/api/useCreateTeam.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { fetchAPI } from '@/api';
+import { APIError, errorCauses, fetchAPI } from '@/api';
 
 import { KEY_LIST_TEAM } from './useTeams';
 
@@ -8,9 +8,6 @@ type CreateTeamResponse = {
   id: string;
   name: string;
 };
-export interface CreateTeamResponseError {
-  detail: string;
-}
 
 export const createTeam = async (name: string): Promise<CreateTeamResponse> => {
   const response = await fetchAPI(`teams/`, {
@@ -21,7 +18,10 @@ export const createTeam = async (name: string): Promise<CreateTeamResponse> => {
   });
 
   if (!response.ok) {
-    throw new Error(`Couldn't create team: ${response.statusText}`);
+    throw new APIError(
+      'Failed to create the team',
+      await errorCauses(response),
+    );
   }
 
   return response.json() as Promise<CreateTeamResponse>;
@@ -33,7 +33,7 @@ interface CreateTeamProps {
 
 export function useCreateTeam({ onSuccess }: CreateTeamProps) {
   const queryClient = useQueryClient();
-  return useMutation<CreateTeamResponse, CreateTeamResponseError, string>({
+  return useMutation<CreateTeamResponse, APIError, string>({
     mutationFn: createTeam,
     onSuccess: (data) => {
       void queryClient.invalidateQueries({

--- a/src/frontend/apps/desk/src/features/teams/api/useTeam.tsx
+++ b/src/frontend/apps/desk/src/features/teams/api/useTeam.tsx
@@ -9,14 +9,25 @@ export type TeamParams = {
 };
 
 export interface TeamResponseError {
-  detail: string;
+  detail?: string;
+  status?: number;
+  cause?: string;
 }
 
 export const getTeam = async ({ id }: TeamParams): Promise<TeamResponse> => {
   const response = await fetchAPI(`teams/${id}`);
 
   if (!response.ok) {
-    throw new Error(`Couldn't fetch team: ${response.statusText}`);
+    if (response.status === 404) {
+      throw {
+        status: 404,
+        message: `Team with id ${id} not found`,
+      };
+    }
+
+    throw new Error(`Couldn't fetch team:`, {
+      cause: ((await response.json()) as TeamResponseError).detail,
+    });
   }
   return response.json() as Promise<TeamResponse>;
 };

--- a/src/frontend/apps/desk/src/features/teams/api/useTeam.tsx
+++ b/src/frontend/apps/desk/src/features/teams/api/useTeam.tsx
@@ -1,6 +1,6 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 
-import { fetchAPI } from '@/api';
+import { APIError, errorCauses, fetchAPI } from '@/api';
 
 import { TeamResponse } from './types';
 
@@ -8,27 +8,13 @@ export type TeamParams = {
   id: string;
 };
 
-export interface TeamResponseError {
-  detail?: string;
-  status?: number;
-  cause?: string;
-}
-
 export const getTeam = async ({ id }: TeamParams): Promise<TeamResponse> => {
   const response = await fetchAPI(`teams/${id}`);
 
   if (!response.ok) {
-    if (response.status === 404) {
-      throw {
-        status: 404,
-        message: `Team with id ${id} not found`,
-      };
-    }
-
-    throw new Error(`Couldn't fetch team:`, {
-      cause: ((await response.json()) as TeamResponseError).detail,
-    });
+    throw new APIError('Failed to get the team', await errorCauses(response));
   }
+
   return response.json() as Promise<TeamResponse>;
 };
 
@@ -36,9 +22,9 @@ export const KEY_TEAM = 'team';
 
 export function useTeam(
   param: TeamParams,
-  queryConfig?: UseQueryOptions<TeamResponse, TeamResponseError, TeamResponse>,
+  queryConfig?: UseQueryOptions<TeamResponse, APIError, TeamResponse>,
 ) {
-  return useQuery<TeamResponse, TeamResponseError, TeamResponse>({
+  return useQuery<TeamResponse, APIError, TeamResponse>({
     queryKey: [KEY_TEAM, param],
     queryFn: () => getTeam(param),
     ...queryConfig,

--- a/src/frontend/apps/desk/src/features/teams/api/useTeams.tsx
+++ b/src/frontend/apps/desk/src/features/teams/api/useTeams.tsx
@@ -5,7 +5,7 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query';
 
-import { APIList, fetchAPI } from '@/api';
+import { APIError, APIList, errorCauses, fetchAPI } from '@/api';
 
 import { TeamResponse } from './types';
 
@@ -22,9 +22,6 @@ type TeamsAPIParams = TeamsParams & {
 };
 
 type TeamsResponse = APIList<TeamResponse>;
-export interface TeamsResponseError {
-  detail: string;
-}
 
 export const getTeams = async ({
   ordering,
@@ -34,7 +31,7 @@ export const getTeams = async ({
   const response = await fetchAPI(`teams/?page=${page}${orderingQuery}`);
 
   if (!response.ok) {
-    throw new Error(`Couldn't fetch teams: ${response.statusText}`);
+    throw new APIError('Failed to get the teams', await errorCauses(response));
   }
   return response.json() as Promise<TeamsResponse>;
 };
@@ -45,7 +42,7 @@ export function useTeams(
   param: TeamsParams,
   queryConfig?: DefinedInitialDataInfiniteOptions<
     TeamsResponse,
-    TeamsResponseError,
+    APIError,
     InfiniteData<TeamsResponse>,
     QueryKey,
     number
@@ -53,7 +50,7 @@ export function useTeams(
 ) {
   return useInfiniteQuery<
     TeamsResponse,
-    TeamsResponseError,
+    APIError,
     InfiniteData<TeamsResponse>,
     QueryKey,
     number

--- a/src/frontend/apps/desk/src/i18n/translations.json
+++ b/src/frontend/apps/desk/src/i18n/translations.json
@@ -40,6 +40,7 @@
       "Last update at": "Dernière modification le",
       "People": "People",
       "People Description": "Description de People",
+      "404 - Page not found": "404 - Page introuvable",
       "Something bad happens, please retry": "Une erreur inattendue s'est produite, rechargez la page.",
       "Panel create new team": "Panneau de création d'un nouveau groupe",
       "icon group": "icône groupe",

--- a/src/frontend/apps/desk/src/pages/404.tsx
+++ b/src/frontend/apps/desk/src/pages/404.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Text } from '@/components';
+import { NextPageWithLayout } from '@/types/next';
+
+import MainLayout from './MainLayout';
+
+const Page: NextPageWithLayout = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Text
+      className="mt-xl"
+      as="h1"
+      $justify="center"
+      $align="center"
+      $theme="danger"
+      $textAlign="center"
+    >
+      {t('404 - Page not found')}
+    </Text>
+  );
+};
+
+Page.getLayout = function getLayout(page: ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
+};
+
+export default Page;

--- a/src/frontend/apps/desk/src/pages/teams/[id].tsx
+++ b/src/frontend/apps/desk/src/pages/teams/[id].tsx
@@ -2,9 +2,9 @@ import { Loader } from '@openfun/cunningham-react';
 import { useRouter as useNavigate } from 'next/navigation';
 import { useRouter } from 'next/router';
 import { ReactElement } from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { Box, Text } from '@/components';
+import { Box } from '@/components';
+import { TextErrors } from '@/components/TextErrors';
 import { TeamInfo, useTeam } from '@/features/teams/';
 import { NextPageWithLayout } from '@/types/next';
 
@@ -27,27 +27,16 @@ interface TeamProps {
 }
 
 const Team = ({ id }: TeamProps) => {
-  const { t } = useTranslation();
   const { data: team, isLoading, isError, error } = useTeam({ id });
   const navigate = useNavigate();
 
-  if (isError) {
+  if (isError && error) {
     if (error.status === 404) {
       navigate.replace(`/404`);
       return null;
     }
 
-    return (
-      <Text
-        $align="center"
-        $justify="center"
-        $height="100%"
-        $theme="danger"
-        $textAlign="center"
-      >
-        {t('Something bad happens, please retry.')}
-      </Text>
-    );
+    return <TextErrors causes={error.cause} />;
   }
 
   if (isLoading || !team) {

--- a/src/frontend/apps/desk/src/pages/teams/[id].tsx
+++ b/src/frontend/apps/desk/src/pages/teams/[id].tsx
@@ -1,4 +1,5 @@
 import { Loader } from '@openfun/cunningham-react';
+import { useRouter as useNavigate } from 'next/navigation';
 import { useRouter } from 'next/router';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,9 +28,15 @@ interface TeamProps {
 
 const Team = ({ id }: TeamProps) => {
   const { t } = useTranslation();
-  const { data: team, isLoading, isError } = useTeam({ id });
+  const { data: team, isLoading, isError, error } = useTeam({ id });
+  const navigate = useNavigate();
 
   if (isError) {
+    if (error.status === 404) {
+      navigate.replace(`/404`);
+      return null;
+    }
+
     return (
       <Text
         $align="center"

--- a/src/frontend/apps/desk/src/pages/teams/create.tsx
+++ b/src/frontend/apps/desk/src/pages/teams/create.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import IconGroup from '@/assets/icons/icon-group2.svg';
 import { Box, Card, StyledLink, Text } from '@/components';
+import { TextErrors } from '@/components/TextErrors';
 import { useCunninghamTheme } from '@/cunningham';
 import { useCreateTeam } from '@/features/teams';
 import { NextPageWithLayout } from '@/types/next';
@@ -18,6 +19,7 @@ const Page: NextPageWithLayout = () => {
     mutate: createTeam,
     isError,
     isPending,
+    error,
   } = useCreateTeam({
     onSuccess: (team) => {
       router.push(`/teams/${team.id}`);
@@ -55,11 +57,7 @@ const Page: NextPageWithLayout = () => {
             onChange={(e) => setTeamName(e.target.value)}
             rightIcon={<span className="material-icons">edit</span>}
           />
-          {isError && (
-            <Text className="mt-s" $theme="danger" $textAlign="center">
-              {t('Something bad happens, please retry.')}
-            </Text>
-          )}
+          {isError && error && <TextErrors causes={error.cause} />}
           {isPending && (
             <Box $align="center">
               <Loader />

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
@@ -95,6 +95,25 @@ test.describe('Teams Create', () => {
     await expect(page).toHaveURL(/\/teams$/);
   });
 
+  test('checks error when duplicate team', async ({ page, browserName }) => {
+    const panel = page.getByLabel('Teams panel').first();
+
+    await panel.getByRole('button', { name: 'Add a team' }).click();
+
+    const teamName = `My duplicate team ${browserName}-${Math.floor(Math.random() * 1000)}`;
+    await page.getByText('Team name').fill(teamName);
+    await page.getByRole('button', { name: 'Create the team' }).click();
+
+    await panel.getByRole('button', { name: 'Add a team' }).click();
+
+    await page.getByText('Team name').fill(teamName);
+    await page.getByRole('button', { name: 'Create the team' }).click();
+
+    await expect(
+      page.getByText('Team with this Slug already exists.'),
+    ).toBeVisible();
+  });
+
   test('checks 404 on teams/[id] page', async ({ page }) => {
     await page.goto('/teams/some-unknown-team');
     await expect(page.getByText('404 - Page not found')).toBeVisible({

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
@@ -94,4 +94,11 @@ test.describe('Teams Create', () => {
     await expect(buttonCreateHomepage).toBeVisible();
     await expect(page).toHaveURL(/\/teams$/);
   });
+
+  test('checks 404 on teams/[id] page', async ({ page }) => {
+    await page.goto('/teams/some-unknown-team');
+    await expect(page.getByText('404 - Page not found')).toBeVisible({
+      timeout: 15000,
+    });
+  });
 });


### PR DESCRIPTION
## Purpose

- Create a 404 page and manage the 404 when we try to access a team that doesn't exist (`/teams/idontexist`).
- We improve the way to catch the api errors, to get an easy way to display dynamically api errors.

## Proposal

- [x] add 404 page
- [x] improve api error management
