### PR TITLE
🎨(frontend) Consistency url

### DIFF
--- a/src/frontend/apps/desk/src/pages/index.tsx
+++ b/src/frontend/apps/desk/src/pages/index.tsx
@@ -1,27 +1,12 @@
-import { Button } from '@openfun/cunningham-react';
 import type { ReactElement } from 'react';
-import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
 
-import { Box, StyledLink } from '@/components';
 import { NextPageWithLayout } from '@/types/next';
 
+import Teams from './teams/';
 import TeamLayout from './teams/TeamLayout';
 
-const StyledButton = styled(Button)`
-  width: fit-content;
-`;
-
 const Page: NextPageWithLayout = () => {
-  const { t } = useTranslation();
-
-  return (
-    <Box $align="center" $justify="center" $height="inherit">
-      <StyledLink href="/teams/create">
-        <StyledButton>{t('Create a new team')}</StyledButton>
-      </StyledLink>
-    </Box>
-  );
+  return <Teams />;
 };
 
 Page.getLayout = function getLayout(page: ReactElement) {

--- a/src/frontend/apps/desk/src/pages/teams/index.tsx
+++ b/src/frontend/apps/desk/src/pages/teams/index.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@openfun/cunningham-react';
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import { Box, StyledLink } from '@/components';
+import { NextPageWithLayout } from '@/types/next';
+
+import TeamLayout from './TeamLayout';
+
+const StyledButton = styled(Button)`
+  width: fit-content;
+`;
+
+const Page: NextPageWithLayout = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box $align="center" $justify="center" $height="inherit">
+      <StyledLink href="/teams/create">
+        <StyledButton>{t('Create a new team')}</StyledButton>
+      </StyledLink>
+    </Box>
+  );
+};
+
+Page.getLayout = function getLayout(page: ReactElement) {
+  return <TeamLayout>{page}</TeamLayout>;
+};
+
+export default Page;

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
@@ -80,4 +80,18 @@ test.describe('Teams Create', () => {
     await panel.locator('li').getByText(teamName).click();
     await expect(elTeam).toBeVisible();
   });
+
+  test('checks alias teams url with homepage', async ({ page }) => {
+    await expect(page).toHaveURL('/');
+
+    const buttonCreateHomepage = page.getByRole('button', {
+      name: 'Create a new team',
+    });
+
+    await expect(buttonCreateHomepage).toBeVisible();
+
+    await page.goto('/teams');
+    await expect(buttonCreateHomepage).toBeVisible();
+    await expect(page).toHaveURL(/\/teams$/);
+  });
 });


### PR DESCRIPTION
## Purpose

We have this kind of url `/teams/1321465`, but `/teams/` gives a 404, it is not a good practice.
We make `/teams` as an alias of the homepage `/`.

## Proposal

- [x] create teams page as alias of home
- [x] test

## Demo 

[scrnli_2_13_2024_12-03-10 PM.webm](https://github.com/numerique-gouv/people/assets/25994652/6d637779-9574-47ee-83d8-90528303677f)

