### PR TITLE
🩹(backend) fix Django Admin UserAdmin page

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -82,6 +82,15 @@ class UserAdmin(auth_admin.UserAdmin):
         ),
         (_("Important dates"), {"fields": ("created_at", "updated_at")}),
     )
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": ("email", "password1", "password2"),
+            },
+        ),
+    )
     inlines = (IdentityInline, TeamAccessInline)
     list_display = (
         "email",

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -288,7 +288,8 @@ class Identity(BaseModel):
 
     def __str__(self):
         main_str = "[main]" if self.is_main else ""
-        return f"{self.email:s}{main_str:s}"
+        id_str = self.email or self.sub
+        return f"{id_str:s}{main_str:s}"
 
     def save(self, *args, **kwargs):
         """Ensure users always have one and only one main identity."""


### PR DESCRIPTION
Fix several issues identified in the Django Admin

 **Broken Identity string representation**
Resolving a format error in the Identity string representation caused by potential `None` values in the email field. This issue was discovered when attempting to access the User details page in the Django Admin

**Broken User creation form**
The replacement of the User's username with an email led to errors in the `UserAdmin` class. The base class used the `username` field in the `add_fieldsets` attribute. This problem was discovered while attempting to create a new user in the Django Admin.

It closes #56.
