### PR TITLE
🐛(project) run production image locally with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     user: ${DOCKER_USER:-1000}
     image: people:production
     environment:
-      - DJANGO_CONFIGURATION=ContinuousIntegration
+      - DJANGO_CONFIGURATION=Demo
     env_file:
       - env.d/development/common
       - env.d/development/postgresql
@@ -81,7 +81,7 @@ services:
     image: people:production
     command: ["celery", "-A", "people.celery_app", "worker", "-l", "INFO"]
     environment:
-      - DJANGO_CONFIGURATION=ContinuousIntegration
+      - DJANGO_CONFIGURATION=Demo
     env_file:
       - env.d/development/common
       - env.d/development/postgresql

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -8,12 +8,12 @@ server {
         alias /data/media;
     }
 
-    # location / {
-    #     proxy_pass http://app:8000;
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    # }
+    location / {
+         proxy_pass http://app:8000;
+         proxy_set_header Host $host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }
 
 server {

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -522,3 +522,22 @@ class PreProduction(Production):
 
     nota bene: it should inherit from the Production environment.
     """
+
+
+class Demo(Production):
+    """
+    Demonstration environment settings
+
+    nota bene: it should inherit from the Production environment.
+    """
+
+    CSRF_TRUSTED_ORIGINS = ["http://localhost:8082"]
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -175,6 +175,7 @@ class Base(Configuration):
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
+        "dockerflow.django.middleware.DockerflowMiddleware",
     ]
 
     AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
## Purpose

Fix Nginx commented broken configuration.

## Proposal

Issue identified on Joanie. The production image, running with docker-compose, uses a Django environment which requires some dev dependencies. Dev dependencies are not installed in the production image.

Create a new Django environment, dedicated to test locally the production image. As the production image was crashing, the Nginx configuration was also broken.

Linked to this issue, our container lacked monitoring container readiness. I have activated container liveness probes, which will be useful in the near future with K8s.
