### PR TITLE
✨(backend) add list and delete endpoints to invitations router

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -381,6 +381,7 @@ class TeamAccessViewSet(
 
 class InvitationViewset(
     mixins.CreateModelMixin,
+    mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
     """API ViewSet for user invitations to team.
@@ -391,15 +392,17 @@ class InvitationViewset(
         - issuer : User, automatically added from user making query, if allowed
         - team : Team, automatically added from requested URI
         Return newly created invitation
+
+    GET /api/v1.0/teams/<team_id>/invitations/
+        Return list of invitations related to that team.
     """
 
     lookup_field = "id"
     pagination_class = Pagination
-    permission_classes = [
-        permissions.AccessPermission,
-        permissions.RelatedTeamAccessPermission,
-    ]
-    queryset = models.Invitation.objects.all().select_related("team")
+    permission_classes = [permissions.AccessPermission]
+    queryset = (
+        models.Invitation.objects.all().select_related("team").order_by("-created_at")
+    )
     serializer_class = serializers.InvitationSerializer
 
     def perform_create(self, serializer, *args, **kwargs):

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -179,6 +179,6 @@ class InvitationFactory(factory.django.DjangoModelFactory):
         model = models.Invitation
 
     email = factory.Faker("email")
-    team = factory.SubFactory(TeamFactory)
     role = factory.fuzzy.FuzzyChoice([role[0] for role in models.RoleChoices.choices])
+    team = factory.SubFactory(TeamFactory)
     issuer = factory.SubFactory(UserFactory)

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -147,6 +147,7 @@ class TeamFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Team
         django_get_or_create = ("name",)
+        skip_postgeneration_save = True
 
     name = factory.Sequence(lambda n: f"team{n}")
 

--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -155,6 +155,10 @@ class Migration(migrations.Migration):
             constraint=models.UniqueConstraint(fields=('user', 'email'), name='unique_user_email', violation_error_message='This email address is already declared for this user.'),
         ),
         migrations.AddConstraint(
+            model_name='invitation',
+            constraint=models.UniqueConstraint(fields=('email', 'team'), name='email_and_team_unique_together'),
+        ),
+        migrations.AddConstraint(
             model_name='teamaccess',
             constraint=models.UniqueConstraint(fields=('user', 'team'), name='unique_team_user', violation_error_message='This user is already in this team.'),
         ),

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -461,6 +461,13 @@ class Invitation(BaseModel):
         related_name="invitations",
     )
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["email", "team"], name="email_and_team_unique_together"
+            )
+        ]
+
     def __str__(self):
         return f"{self.email} invited to {self.team}"
 

--- a/src/backend/core/tests/teams/test_core_api_teams_list.py
+++ b/src/backend/core/tests/teams/test_core_api_teams_list.py
@@ -26,8 +26,10 @@ def test_api_teams_list_anonymous():
 
 
 def test_api_teams_list_authenticated():
-    """Authenticated users should be able to list teams
-    they arean owner/administrator/member of."""
+    """
+    Authenticated users should be able to list teams they are
+    owner/administrator/member of.
+    """
     identity = factories.IdentityFactory()
     user = identity.user
 

--- a/src/backend/core/tests/test_api_team_invitations.py
+++ b/src/backend/core/tests/test_api_team_invitations.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for the Invitation model
+"""
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core import factories
+from core.api import serializers
+
+from .utils import OIDCToken
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_team_invitations_anonymous():
+    """Anonymous users should not be able to create invitations."""
+    team = factories.TeamFactory()
+    invitation_values = serializers.InvitationSerializer(
+        factories.InvitationFactory.build()
+    ).data
+
+    response = APIClient().post(
+        f"/api/v1.0/teams/{team.id}/invitations/",
+        invitation_values,
+        format="json",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+def test_api_team_invitations_authenticated_outsider():
+    """Users outside of team should not be permitted to invite to team."""
+    identity = factories.IdentityFactory()
+    jwt_token = OIDCToken.for_user(identity.user)
+
+    team = factories.TeamFactory()  # user not in team
+    invitation_values = serializers.InvitationSerializer(
+        factories.InvitationFactory.build()
+    ).data
+
+    response = APIClient().post(
+        f"/api/v1.0/teams/{team.id}/invitations/",
+        invitation_values,
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        ("owner", status.HTTP_201_CREATED),
+        ("administrator", status.HTTP_201_CREATED),
+        ("member", status.HTTP_403_FORBIDDEN),
+    ],
+)
+def test_api_team_invitations_team_members(parameters):
+    """
+    Owners and administrators should be able to invite new members.
+    Simple members however, should not.
+    """
+    identity = factories.IdentityFactory()
+    jwt_token = OIDCToken.for_user(identity.user)
+
+    team = factories.TeamFactory(users=[(identity.user, parameters[0])])
+    invitation_values = serializers.InvitationSerializer(
+        factories.InvitationFactory.build()
+    ).data
+
+    response = APIClient().post(
+        f"/api/v1.0/teams/{team.id}/invitations/",
+        invitation_values,
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+    )
+    assert response.status_code == parameters[1]
+
+
+def test_invitation_issuer_and_team_automatically_added():
+    """Team and issuer fields should auto-complete."""
+    identity = factories.IdentityFactory()
+    jwt_token = OIDCToken.for_user(identity.user)
+
+    team = factories.TeamFactory(users=[(identity.user, "owner")])
+    invitation_values = serializers.InvitationSerializer(
+        factories.InvitationFactory.build()
+    ).data
+
+    response = APIClient().post(
+        f"/api/v1.0/teams/{team.id}/invitations/",
+        invitation_values,
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    # team and issuer automatically set
+    assert response.json()["team"] == str(team.id)
+    assert response.json()["issuer"] == str(identity.user.id)
+
+
+def test_api_team_invitations_cannot_duplicate_invitation():
+    """An email should not be invited multiple times to the same team."""
+    existing_invitation = factories.InvitationFactory()
+    team = existing_invitation.team
+
+    identity = factories.IdentityFactory()
+    jwt_token = OIDCToken.for_user(identity.user)
+
+    factories.TeamAccessFactory(team=team, user=identity.user, role="administrator")
+    invitation_values = serializers.InvitationSerializer(existing_invitation).data
+
+    response = APIClient().post(
+        f"/api/v1.0/teams/{team.id}/invitations/",
+        invitation_values,
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["__all__"] == [
+        "Invitation with this Email address and Team already exists."
+    ]

--- a/src/backend/people/api_urls.py
+++ b/src/backend/people/api_urls.py
@@ -21,6 +21,11 @@ team_related_router.register(
     basename="team_accesses",
 )
 
+invitation_router = DefaultRouter()
+invitation_router.register(
+    "invitations", viewsets.InvitationViewset, basename="invitations"
+)
+
 urlpatterns = [
     path(
         f"api/{settings.API_VERSION}/",
@@ -31,6 +36,10 @@ urlpatterns = [
                 re_path(
                     r"^teams/(?P<team_id>[0-9a-z-]*)/",
                     include(team_related_router.urls),
+                ),
+                re_path(
+                    r"^teams/(?P<team_id>[0-9a-z-]*)/",
+                    include(invitation_router.urls),
                 ),
             ]
         ),


### PR DESCRIPTION
## Purpose

Add an invitation router, nested below teams/ 
- `create` to allow team owners/administrators to invite members
- `list` pending and expired invitations
- `delete` to cancel invitations

## Proposal

In a manner similar to #50, continue CRUD actions to complete `team/<team_id>/invitations/` route
- [x] add route and viewset
- [x] add create action
- [x]  add uniqueness together to avoid duplicate of email in the same team
- [x] permission tests
- [x] list 
- [x] tests list
- [ ] test expired invitations are listed too
- [ ] delete endpoint 
- [ ] tests delete

Retrieve and update actions will be dealt with later.