### PR TITLE
🚧(api) order team accesses by role, email or name

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2,6 +2,7 @@
 from django.contrib.postgres.search import TrigramSimilarity
 from django.db.models import Func, Max, OuterRef, Prefetch, Q, Subquery, Value
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import (
     decorators,
     exceptions,
@@ -316,6 +317,15 @@ class TeamAccessViewSet(
     queryset = models.TeamAccess.objects.all().select_related("user")
     list_serializer_class = serializers.TeamAccessReadOnlySerializer
     detail_serializer_class = serializers.TeamAccessSerializer
+    filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
+    ordering_fields = [
+        "role",
+        "user__email",
+        "user__name",
+        "user__main_identity__email",
+        "user__main_identity__name",
+    ]
+    ordering = ["role"]
 
     def get_permissions(self):
         """User only needs to be authenticated to list team accesses"""

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -193,6 +193,7 @@ class Base(Configuration):
         "corsheaders",
         "dockerflow.django",
         "rest_framework",
+        # 'django_filters',
         "parler",
         "easy_thumbnails",
         # Django

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "django-timezone-field>=5.1",
     "django==5.0.2",
     "djangorestframework==3.14.0",
+    "django-filter==23.5",
     "drf_spectacular==0.27.1",
     "dockerflow==2024.2.0",
     "easy_thumbnails==2.8.5",


### PR DESCRIPTION
## Purpose

Allows users to order results of GET on team/<id>/accesses/ endpoint. This is a work in progress.

## Proposal

Description...

- [x] sort by role
- [] sort by email or name
- [x] dedicated test
