### PR TITLE
Fix team's accesses abilities

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -348,7 +348,7 @@ class TeamAccessViewSet(
             # instance for the logged-in user (we don't want to list only the team access
             # instances pointing to the logged-in user)
             user_role_query = models.TeamAccess.objects.filter(
-                team__accesses__user=self.request.user
+                user=self.request.user, team=self.kwargs["team_id"]
             ).values("role")[:1]
 
             queryset = (


### PR DESCRIPTION
## Purpose

Abilities on team's accesses were wrongly computed.

## Proposal

This bug was highlighted by @AntoLC, it closes #87 

- [X] Enhance test coverage
- [X] Fix Team Accesses `get_queryset`
- [X] Enhance documentation
