### PR TITLE
🧑‍💻(demo) improve distribution in number of identities per user

### DIFF
--- a/src/backend/demo/defaults.py
+++ b/src/backend/demo/defaults.py
@@ -3,6 +3,5 @@
 NB_OBJECTS = {
     "users": 1000,
     "teams": 100,
-    "max_identities_per_user": 3,
     "max_users_per_team": 100,
 }

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -129,16 +129,19 @@ def create_demo(stdout):
         users_values = list(models.User.objects.values("id", "email"))
         for user_dict in users_values:
             for i in range(
-                random.randint(0, defaults.NB_OBJECTS["max_identities_per_user"])
+                random.choices(range(5), weights=[5, 50, 30, 10, 5], k=1)[0]
             ):
                 user_email = user_dict["email"]
                 queue.push(
                     models.Identity(
                         user_id=user_dict["id"],
                         sub=uuid4(),
-                        email=f"identity{i:d}{user_email:s}",
                         is_main=(i == 0),
-                        name=fake.name(),
+                        # Leave 3% of emails and names empty
+                        email=f"identity{i:d}{user_email:s}"
+                        if random.random() < 0.97
+                        else None,
+                        name=fake.name() if random.random() < 0.97 else None,
                     )
                 )
         queue.flush()


### PR DESCRIPTION
## Purpose

The current implementation of our product demo via the make command lacks user identity for a significant portion of generated users, limiting the realism of the showcased scenarios. As it stands, users created by the make command lack complete information, such as full names and email addresses, because they don't have any identity.

## Proposal 

I tried to come up with the simplest solution: we now generate a very small portion of our users with 0 identities. The probability for users to have only 1 identity is the highest but they can have up to 4 with decreasing probabilities. I removed the possibility to set a maximum number of identities as it doesn't bring any value.

3% of the identities created will have no email and 3% will have no name.

Fixes https://github.com/numerique-gouv/people/issues/90
