### PR TITLE
🌐(app-desk) translate role in member grid

### DIFF
--- a/src/frontend/apps/desk/src/features/teams/__tests__/MemberGrid.test.tsx
+++ b/src/frontend/apps/desk/src/features/teams/__tests__/MemberGrid.test.tsx
@@ -84,9 +84,9 @@ describe('MemberGrid', () => {
     expect(screen.getByText('user1@test.com')).toBeInTheDocument();
     expect(screen.getByText('user2@test.com')).toBeInTheDocument();
     expect(screen.getByText('user3@test.com')).toBeInTheDocument();
-    expect(screen.getByText(Role.OWNER)).toBeInTheDocument();
-    expect(screen.getByText(Role.ADMIN)).toBeInTheDocument();
-    expect(screen.getByText(Role.MEMBER)).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
   });
 
   it('checks the pagination', async () => {

--- a/src/frontend/apps/desk/src/features/teams/components/Member/MemberGrid.tsx
+++ b/src/frontend/apps/desk/src/features/teams/components/Member/MemberGrid.tsx
@@ -33,6 +33,12 @@ export const MemberGrid = ({ teamId, currentRole }: MemberGridProps) => {
     setPagesCount(data?.count ? Math.ceil(data.count / pageSize) : 0);
   }, [data?.count, pageSize, setPagesCount]);
 
+  const dictRole = {
+    [Role.ADMIN]: t('Admin'),
+    [Role.MEMBER]: t('Member'),
+    [Role.OWNER]: t('Owner'),
+  };
+
   return (
     <Card
       className="m-b pb-s"
@@ -78,8 +84,11 @@ export const MemberGrid = ({ teamId, currentRole }: MemberGridProps) => {
             headerName: t('Emails'),
           },
           {
-            field: 'role',
+            id: 'role',
             headerName: t('Roles'),
+            renderCell({ row }) {
+              return dictRole[row.role];
+            },
           },
           {
             id: 'column-actions',

--- a/src/frontend/apps/e2e/__tests__/app-desk/team.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/team.spec.ts
@@ -60,7 +60,7 @@ test.describe('Team', () => {
       new RegExp(`E2E ${browserName}`, 'i'),
     );
     await expect(cells.nth(2)).toHaveText(`user@${browserName}.e2e`);
-    await expect(cells.nth(3)).toHaveText('owner');
+    await expect(cells.nth(3)).toHaveText(/Owner/i);
   });
 
   test('try to update the owner role but cannot because it is the last owner', async ({


### PR DESCRIPTION
## Purpose

The roles in the member grid were not being translated. This PR adds the translation for
the roles in the member grid.

## Proposal

- [x] Add translated roles

## Demo

![image](https://github.com/numerique-gouv/people/assets/25994652/5296e9fe-6094-4e0f-af2d-a9119c094955)
