### PR TITLE
🐛(app-desk) close dropDown when click outside

### DIFF
--- a/src/frontend/apps/desk/src/components/DropButton.tsx
+++ b/src/frontend/apps/desk/src/components/DropButton.tsx
@@ -44,19 +44,22 @@ export const DropButton = ({
     setIsLocalOpen(isOpen);
   }, [isOpen]);
 
+  const onOpenChangeHandler = (isOpen: boolean) => {
+    setIsLocalOpen(isOpen);
+    onOpenChange?.(isOpen);
+    setTimeout(() => {
+      setOpacity(isOpen);
+    }, 10);
+  };
+
   return (
-    <DialogTrigger
-      onOpenChange={(isOpen) => {
-        setIsLocalOpen(isOpen);
-        onOpenChange?.(isOpen);
-        setTimeout(() => {
-          setOpacity(isOpen);
-        }, 10);
-      }}
-      isOpen={isLocalOpen}
-    >
+    <DialogTrigger onOpenChange={onOpenChangeHandler} isOpen={isLocalOpen}>
       <StyledButton>{button}</StyledButton>
-      <StyledPopover style={{ opacity: opacity ? 1 : 0 }} isOpen={isLocalOpen}>
+      <StyledPopover
+        style={{ opacity: opacity ? 1 : 0 }}
+        isOpen={isLocalOpen}
+        onOpenChange={onOpenChangeHandler}
+      >
         {children}
       </StyledPopover>
     </DialogTrigger>


### PR DESCRIPTION
## Purpose

When we were clicking outside the dropdown, the dropdown was not closing.
This PR fixes that.

See: #110

## Demo

[scrnli_3_13_2024_4-09-54 PM.webm](https://github.com/numerique-gouv/people/assets/25994652/cb1a4467-de9d-45da-b78d-63830aead64b)
