### PR TITLE
✨(backend) convert invitations to accesses

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "responses==0.25.0",
     "ruff==0.3.2",
     "types-requests==2.31.0.20240311",
+    "freezegun==1.4.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Purpose

Convert invitations to accesses upon creating a new identity.

## Proposal

- [x] modify the `save` method on Identity (could have been in pre or post_save signals but Django recommends against it)
- [x] write a positive test : invitation converted and access granted
- [x] write a negative test for expired invitations

I don't remember why but I had noted down that we could add the logic of this PR in `create_user` ([here](https://github.com/numerique-gouv/people/blob/29d274ab7c94768f30752319cabbcc1aee7db142/src/backend/core/authentication.py#L108))
I think it's better to link it to the Identity model because identities and invitations both revolve around the same emails. We could imagine by instance that, later on, upon linking identities to my existing user, I get all the extra accesses linked to my new email/identity.