### PR TITLE
✨(api) support ordering when listing team's accesses

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -326,6 +326,10 @@ class TeamAccessViewSet(
     list_serializer_class = serializers.TeamAccessReadOnlySerializer
     detail_serializer_class = serializers.TeamAccessSerializer
 
+    filter_backends = [filters.OrderingFilter]
+    ordering = ['role']
+    ordering_fields = ['role']
+
     def get_permissions(self):
         """User only needs to be authenticated to list team accesses"""
         if self.action == "list":

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -97,7 +97,6 @@ class SerializerPerActionMixin:
 class Pagination(pagination.PageNumberPagination):
     """Pagination to display no more than 100 objects per page sorted by creation date."""
 
-    ordering = "-created_on"
     max_page_size = 100
     page_size_query_param = "page_size"
 

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -124,6 +124,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.User
+        django_get_or_create = ("email",)
 
     email = factory.Faker("email")
     language = factory.fuzzy.FuzzyChoice([lang[0] for lang in settings.LANGUAGES])

--- a/src/backend/core/tests/test_models_users.py
+++ b/src/backend/core/tests/test_models_users.py
@@ -36,13 +36,13 @@ def test_models_users_email_unique():
     with pytest.raises(
         ValidationError, match="User with this Email address already exists."
     ):
-        factories.UserFactory(email=user.email)
+        models.User.objects.create(email=user.email)
 
 
 def test_models_users_email_several_null():
     """Several users with a null value for the "email" field can co-exist."""
     factories.UserFactory(email=None)
-    factories.UserFactory(email=None)
+    models.User.objects.create(email=None, password="foo.")
 
     assert models.User.objects.filter(email__isnull=True).count() == 2
 


### PR DESCRIPTION
## Purpose

Offer the necessary ordering field to enhance UX when manipulating Team's data in the member grid.

## Proposal

Add API ordering fields on the TeamAccess endpoint. Please note that, frontend is almost ready, and being blocked by issue on Cunnigham side. One was merged, another is still being discussed. 

I prefer shipping the backend first, and opening a new PR for the frontend when all elements will be available.

This PR is related to #81 