### PR TITLE
Enable sorting on columns

### DIFF
--- a/src/frontend/apps/desk/src/features/members/api/useTeamsAccesses.tsx
+++ b/src/frontend/apps/desk/src/features/members/api/useTeamsAccesses.tsx
@@ -7,6 +7,7 @@ import { Access } from '../types';
 export type TeamAccessesAPIParams = {
   page: number;
   teamId: string;
+  ordering?: string;
 };
 
 type AccessesResponse = APIList<Access>;
@@ -14,8 +15,15 @@ type AccessesResponse = APIList<Access>;
 export const getTeamAccesses = async ({
   page,
   teamId,
+  ordering,
 }: TeamAccessesAPIParams): Promise<AccessesResponse> => {
-  const response = await fetchAPI(`teams/${teamId}/accesses/?page=${page}`);
+  let url = `teams/${teamId}/accesses/?page=${page}`;
+
+  if (ordering) {
+    url += '&ordering=' + ordering;
+  }
+
+  const response = await fetchAPI(url);
 
   if (!response.ok) {
     throw new APIError(


### PR DESCRIPTION
## Purpose

Enhance UX while using the member grid.

## Description

Enable sorting on columns. 

Few issues were (or will be) opened on Cunningham. Sorting on Role [was shipped](https://github.com/openfun/cunningham/issues/298), we are waiting for their next release.


https://github.com/numerique-gouv/people/assets/45729124/5d0dbcdb-ba4b-48f1-b11a-e875d558c673



