### PR TITLE
🧑‍💻(frontend) remove CI control on traduction frontend

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Test App
         run: yarn app:test
 
-      - name: Test Translations
-        run: yarn i18n:test
-
   lint-front:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Purpose

The CI was controlling if the traduction was made in every PR. It makes the workflow quite grueling when we have to change the literal, plus the synch is complicating when we have multiple PR opened.

We remove the CI control on the traduction, we will do dedicated PR to update the traduction.

We will add the CI control on the traduction in the future, before a release by example.

## Proposal

- [x] remove the CI control on the traduction

