### PR TITLE
🔧(renovate) open Renovate PR with a default noChangeLog label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["github>numerique-gouv/renovate-configuration"],
   "dependencyDashboard": true,
+  "labels": ["dependencies", "noChangeLog"],
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
Discussed with @sampaccoud, Renovate PR do not necessitate ChangeLog updates Our CI system requires a 'noChangeLog' label or an updated ChangeLog. Currently, we manually add the label for each Renovate PR.

To improve DX, we'll configure Renovate to apply the label automatically.