### PR TITLE
🐛(app-desk) router dynamic

### DIFF
--- a/src/frontend/apps/desk/conf/default.conf
+++ b/src/frontend/apps/desk/conf/default.conf
@@ -12,6 +12,10 @@ server {
     error_page 404 /teams/[id]/;
   }
 
+  location /mail-domains/ {
+    error_page 404 /mail-domains/[slug]/;
+  }
+
   error_page 404 /404.html;
   location = /404.html {
       internal;

--- a/src/frontend/apps/desk/conf/default.conf
+++ b/src/frontend/apps/desk/conf/default.conf
@@ -8,6 +8,10 @@ server {
       try_files $uri index.html $uri/ =404;
   }
 
+  location /teams/ {
+    error_page 404 /teams/[id]/;
+  }
+
   error_page 404 /404.html;
   location = /404.html {
       internal;

--- a/src/frontend/apps/desk/next.config.js
+++ b/src/frontend/apps/desk/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  trailingSlash: true,
   images: {
     unoptimized: true,
   },

--- a/src/frontend/apps/e2e/__tests__/app-desk/footer.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/footer.spec.ts
@@ -56,17 +56,17 @@ test.describe('Footer', () => {
     {
       linkName: 'Legal Notice',
       pageName: 'Legal Notice',
-      url: '/legal-notice',
+      url: '/legal-notice/',
     },
     {
       linkName: 'Personal data and cookies',
       pageName: 'Personal data and cookies',
-      url: '/personal-data-cookies',
+      url: '/personal-data-cookies/',
     },
     {
       linkName: 'Accessibility: non-compliant',
       pageName: 'Accessibility statement',
-      url: '/accessibility',
+      url: '/accessibility/',
     },
   ];
   for (const { linkName, url, pageName } of legalPages) {

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -110,10 +110,10 @@ test.describe('Mail domain', () => {
 
     await clickOnMailDomainsNavButton(page);
 
-    await expect(page).toHaveURL(/mail-domains/);
+    await expect(page).toHaveURL(/mail-domains\//);
 
     await page.getByRole('listbox').first().getByText('domain.fr').click();
-    await expect(page).toHaveURL(/mail-domains\/domainfr/);
+    await expect(page).toHaveURL(/mail-domains\/domainfr\//);
 
     await expect(
       page.getByRole('heading', { name: /domain\.fr/ }).first(),
@@ -192,10 +192,10 @@ test.describe('Mail domain', () => {
 
     await clickOnMailDomainsNavButton(page);
 
-    await expect(page).toHaveURL(/mail-domains/);
+    await expect(page).toHaveURL(/mail-domains\//);
 
     await page.getByRole('listbox').first().getByText('domain.fr').click();
-    await expect(page).toHaveURL(/mail-domains\/domainfr/);
+    await expect(page).toHaveURL(/mail-domains\/domainfr\//);
 
     await expect(
       page.getByRole('heading', { name: 'domain.fr' }),

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
@@ -49,7 +49,7 @@ test.describe('Mail domains', () => {
         .getByLabel(`Mail Domains button`)
         .click();
 
-      await expect(page).toHaveURL(/mail-domains/);
+      await expect(page).toHaveURL(/mail-domains\//);
 
       const responsePromiseSortDesc = page.waitForResponse(
         (response) =>
@@ -105,7 +105,7 @@ test.describe('Mail domains', () => {
         .first()
         .getByLabel(`Mail Domains button`)
         .click();
-      await expect(page).toHaveURL(/mail-domains/);
+      await expect(page).toHaveURL(/mail-domains\//);
       await expect(
         page.getByLabel('mail domains panel', { exact: true }),
       ).toBeVisible();
@@ -129,7 +129,7 @@ test.describe('Mail domains', () => {
         .first()
         .getByLabel(`Mail Domains button`)
         .click();
-      await expect(page).toHaveURL(/mail-domains/);
+      await expect(page).toHaveURL(/mail-domains\//);
       await expect(
         page.getByLabel('mail domains panel', { exact: true }),
       ).toBeVisible();

--- a/src/frontend/apps/e2e/__tests__/app-desk/menu.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/menu.spec.ts
@@ -18,7 +18,7 @@ test.describe('Menu', () => {
     {
       name: 'Mail Domains',
       isDefault: false,
-      expectedUrl: '/mail-domains',
+      expectedUrl: '/mail-domains/',
       expectedText: 'Mail Domains',
     },
   ];

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-create.spec.ts
@@ -90,9 +90,9 @@ test.describe('Teams Create', () => {
 
     await expect(buttonCreateHomepage).toBeVisible();
 
-    await page.goto('/teams');
+    await page.goto('/teams/');
     await expect(buttonCreateHomepage).toBeVisible();
-    await expect(page).toHaveURL(/\/teams$/);
+    await expect(page).toHaveURL(/\/teams\//);
   });
 
   test('checks error when duplicate team', async ({ page, browserName }) => {


### PR DESCRIPTION
## Purpose

When we use the static mode, Next.js want that we build our team pages at build time. But we can't do that because users can create a team at runtime.
So we redirect thanks to ngnix when a user try to access a team page (`teams/[id]`) when we see that a team page is not found.

See more here: #127

## Proposal

- [x] redirect `teams` on Desk ngnix conf
- [x] redirect `mail-domains` on Desk ngnix conf

## Demo

[scrnli_6_27_2024_5-17-40 PM.webm](https://github.com/numerique-gouv/people/assets/25994652/b0685acf-e162-4035-96a9-c701615c77f2)
