### PR TITLE
🩹(frontend) disable submission button while a request is pending

### DIFF
--- a/src/frontend/apps/desk/src/features/addMembers/components/ModalAddMembers.tsx
+++ b/src/frontend/apps/desk/src/features/addMembers/components/ModalAddMembers.tsx
@@ -54,8 +54,12 @@ export const ModalAddMembers = ({
   const [selectedMembers, setSelectedMembers] = useState<OptionsSelect>([]);
   const [selectedRole, setSelectedRole] = useState<Role>(Role.MEMBER);
   const { toast } = useToastProvider();
-  const { mutateAsync: createInvitation } = useCreateInvitation();
-  const { mutateAsync: createTeamAccess } = useCreateTeamAccess();
+  const { mutateAsync: createInvitation, isPending: isPendingInvitation } =
+    useCreateInvitation();
+  const { mutateAsync: createTeamAccess, isPending: isPendingTeamAccess } =
+    useCreateTeamAccess();
+
+  const isPending = isPendingTeamAccess || isPendingInvitation;
 
   const switchActions = (selectedMembers: OptionsSelect) =>
     selectedMembers.map(async (selectedMember) => {
@@ -133,7 +137,12 @@ export const ModalAddMembers = ({
     <Modal
       isOpen
       leftActions={
-        <Button color="secondary" fullWidth onClick={onClose}>
+        <Button
+          color="secondary"
+          fullWidth
+          onClick={onClose}
+          disabled={isPending}
+        >
           {t('Cancel')}
         </Button>
       }
@@ -144,7 +153,7 @@ export const ModalAddMembers = ({
         <Button
           color="primary"
           fullWidth
-          disabled={!selectedMembers.length}
+          disabled={!selectedMembers.length || isPending}
           onClick={() => void handleValidate()}
         >
           {t('Validate')}
@@ -162,7 +171,11 @@ export const ModalAddMembers = ({
     >
       <GlobalStyle />
       <Box className="mb-xl mt-l">
-        <SearchMembers team={team} setSelectedMembers={setSelectedMembers} />
+        <SearchMembers
+          team={team}
+          setSelectedMembers={setSelectedMembers}
+          disabled={isPending}
+        />
         {selectedMembers.length > 0 && (
           <Box className="mt-s">
             <Text as="h4" $textAlign="left" className="mb-t">
@@ -170,7 +183,7 @@ export const ModalAddMembers = ({
             </Text>
             <ChooseRole
               currentRole={currentRole}
-              disabled={false}
+              disabled={isPending}
               defaultRole={Role.MEMBER}
               setRole={setSelectedRole}
             />

--- a/src/frontend/apps/desk/src/features/addMembers/components/SearchMembers.tsx
+++ b/src/frontend/apps/desk/src/features/addMembers/components/SearchMembers.tsx
@@ -14,11 +14,13 @@ export type OptionsSelect = Options<OptionSelect>;
 interface SearchMembersProps {
   team: Team;
   setSelectedMembers: (value: OptionsSelect) => void;
+  disabled?: boolean;
 }
 
 export const SearchMembers = ({
   team,
   setSelectedMembers,
+  disabled,
 }: SearchMembersProps) => {
   const { t } = useTranslation();
   const [input, setInput] = useState('');
@@ -86,6 +88,7 @@ export const SearchMembers = ({
 
   return (
     <AsyncSelect
+      isDisabled={disabled}
       aria-label={t('Find a member to add to the team')}
       isMulti
       loadOptions={loadOptions}

--- a/src/frontend/apps/desk/src/features/members/components/ModalRole.tsx
+++ b/src/frontend/apps/desk/src/features/members/components/ModalRole.tsx
@@ -38,6 +38,7 @@ export const ModalRole = ({
     mutate: updateTeamAccess,
     error: errorUpdate,
     isError: isErrorUpdate,
+    isPending,
   } = useUpdateTeamAccess({
     onSuccess: () => {
       toast(t('The role has been updated'), VariantType.SUCCESS, {
@@ -64,7 +65,12 @@ export const ModalRole = ({
     <Modal
       isOpen
       leftActions={
-        <Button color="secondary" fullWidth onClick={() => onClose()}>
+        <Button
+          color="secondary"
+          fullWidth
+          onClick={() => onClose()}
+          disabled={isPending}
+        >
           {t('Cancel')}
         </Button>
       }
@@ -82,7 +88,7 @@ export const ModalRole = ({
               accessId: access.id,
             });
           }}
-          disabled={isNotAllowed}
+          disabled={isNotAllowed || isPending}
         >
           {t('Validate')}
         </Button>

--- a/src/frontend/apps/desk/src/features/teams/components/CardCreateTeam.tsx
+++ b/src/frontend/apps/desk/src/features/teams/components/CardCreateTeam.tsx
@@ -57,7 +57,10 @@ export const CardCreateTeam = () => {
         <StyledLink href="/">
           <Button color="secondary">{t('Cancel')}</Button>
         </StyledLink>
-        <Button onClick={() => createTeam(teamName)} disabled={!teamName}>
+        <Button
+          onClick={() => createTeam(teamName)}
+          disabled={!teamName || isPending}
+        >
           {t('Create the team')}
         </Button>
       </Box>


### PR DESCRIPTION
If any request is taking longer than expected, the user could interact with the frontend, thinking the previous submission was not taken into account, and would re-submit a request.

It happened to me while sending an invitation. Replaying the request can either lead to inconsistencies in db for the user, or to errors in requests' response.

I propose to disable all interactive button while submitting a request. It's good enough for this actual sprint, these types of interactivity issues could be improved later on.

Please find an example where I sleep during a few seconds to simulate what could happen.

https://github.com/numerique-gouv/people/assets/45729124/cac979cd-93b3-408c-8069-59622d2a08e7


