### PR TITLE
🚸(app-desk) cannot select user or email already selected

### DIFF
--- a/src/frontend/apps/desk/src/features/addMembers/api/useUsers.tsx
+++ b/src/frontend/apps/desk/src/features/addMembers/api/useUsers.tsx
@@ -2,18 +2,25 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 
 import { APIError, APIList, errorCauses, fetchAPI } from '@/api';
 import { User } from '@/core/auth';
+import { Team } from '@/features/teams';
 
 export type UsersParams = {
   query: string;
+  teamId: Team['id'];
 };
 
 type UsersResponse = APIList<User>;
 
 export const getUsers = async ({
   query,
+  teamId,
 }: UsersParams): Promise<UsersResponse> => {
-  const queryParam = query ? `q=${query}` : '';
-  const response = await fetchAPI(`users/?${queryParam}`);
+  const queriesParams = [];
+  queriesParams.push(query ? `q=${query}` : '');
+  queriesParams.push(teamId ? `team_id=${teamId}` : '');
+  const queryParams = queriesParams.filter(Boolean).join('&');
+
+  const response = await fetchAPI(`users/?${queryParams}`);
 
   if (!response.ok) {
     throw new APIError('Failed to get the users', await errorCauses(response));

--- a/src/frontend/apps/desk/src/features/addMembers/components/ModalAddMembers.tsx
+++ b/src/frontend/apps/desk/src/features/addMembers/components/ModalAddMembers.tsx
@@ -162,7 +162,11 @@ export const ModalAddMembers = ({
     >
       <GlobalStyle />
       <Box className="mb-xl mt-l">
-        <SearchMembers team={team} setSelectedMembers={setSelectedMembers} />
+        <SearchMembers
+          team={team}
+          setSelectedMembers={setSelectedMembers}
+          selectedMembers={selectedMembers}
+        />
         {selectedMembers.length > 0 && (
           <Box className="mt-s">
             <Text as="h4" $textAlign="left" className="mb-t">

--- a/src/frontend/apps/e2e/__tests__/app-desk/member-create.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/member-create.spec.ts
@@ -176,14 +176,9 @@ test.describe('Members Create', () => {
     await page.getByLabel('Add members to the team').click();
 
     await inputSearch.fill('test');
-    await page.getByRole('option', { name: users[0].name }).click();
-    await page.getByRole('radio', { name: 'Owner' }).click();
-
-    await page.getByRole('button', { name: 'Validate' }).click();
-
     await expect(
-      page.getByText(`Failed to add ${users[0].name} in the team`),
-    ).toBeVisible();
+      page.getByRole('option', { name: users[0].name }),
+    ).toBeHidden();
   });
 
   test('it try to add twice the same invitation', async ({
@@ -218,12 +213,6 @@ test.describe('Members Create', () => {
     await page.getByLabel('Add members to the team').click();
 
     await inputSearch.fill(email);
-    await page.getByRole('option', { name: email }).click();
-
-    await page.getByRole('button', { name: 'Validate' }).click();
-
-    await expect(
-      page.getByText(`Failed to create the invitation for ${email}`),
-    ).toBeVisible();
+    await expect(page.getByRole('option', { name: email })).toBeHidden();
   });
 });


### PR DESCRIPTION
## Purpose

Cannot select user or email already selected.

Lot of flakiness was appearing, we remove the tests e2e with Firefox.

## Proposal

- [x] Add the teamid to the useUsers query, to not get the users that are already in the team
- [x] Add a check to not select a user or email that is already selected
- [x] Remove Firefox from tests e2e