### PR TITLE
🚨(app-desk) remove warning next.js about css from Head

### DIFF
--- a/src/frontend/apps/desk/src/features/header/ApplicationsMenu.tsx
+++ b/src/frontend/apps/desk/src/features/header/ApplicationsMenu.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import Script from 'next/script';
 import React from 'react';
 
@@ -12,15 +11,13 @@ import React from 'react';
  * This PoC has been created by @manuhabitela.
  *
  * It includes external CSS and JavaScript files for styling and functionality.
+ *
+ * Style has to be included as well: https://suite-numerique-gaufre.osc-fr1.scalingo.io/public/styles/gaufre-vanilla.css \
+ * To respect next.js standards, the css is included using the `_document.ts` component.
+ * @see https://github.com/numerique-gouv/people/blob/main/src/frontend/apps/desk/src/pages/_document.tsx#L8
  */
 export const ApplicationsMenu = () => (
   <>
-    <Head>
-      <link
-        rel="stylesheet"
-        href="https://suite-numerique-gaufre.osc-fr1.scalingo.io/public/styles/gaufre-vanilla.css"
-      />
-    </Head>
     <Script
       src="https://suite-numerique-gaufre.osc-fr1.scalingo.io/public/widget.js"
       strategy="lazyOnload"

--- a/src/frontend/apps/desk/src/pages/_document.tsx
+++ b/src/frontend/apps/desk/src/pages/_document.tsx
@@ -2,10 +2,21 @@ import { Head, Html, Main, NextScript } from 'next/document';
 
 import '@/i18n/initI18n';
 
+/**
+ * About the Gaufre Vanilla CSS
+ * To respect next.js standards, the css is included here.
+ * This css is used with features/header/ApplicationsMenu component.
+ * If the ApplicationsMenu component is removed, this css can be removed as well.
+ */
 export default function RootLayout() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://suite-numerique-gaufre.osc-fr1.scalingo.io/public/styles/gaufre-vanilla.css"
+        />
+      </Head>
       <body suppressHydrationWarning={process.env.NODE_ENV === 'development'}>
         <Main />
         <NextScript />


### PR DESCRIPTION
## Purpose

Importing the css from Head was causing a flickering effect on the button, because of the time the css
load. Next.js was emitting as well a warning about css being loaded from the Head component.
We moved the css import to the _document.tsx file as recommended by the Next.js documentation.


## See

### Warning
![Capture d'écran 2024-03-29 112942](https://github.com/numerique-gouv/people/assets/25994652/ad712858-3c6b-48f9-9b5f-aa4394ea563a)

### Flickering
[scrnli_3_29_2024_11-46-32 AM.webm](https://github.com/numerique-gouv/people/assets/25994652/821d44ba-22aa-4479-9b14-595ab6fceee1)
