### PR TITLE
⚡️(CI) persist the frontend between jobs

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -58,11 +58,9 @@ jobs:
             exit 1
           fi
 
-  test-front:
+  install-front:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/frontend/
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -71,40 +69,85 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-          cache: 'yarn'
-          cache-dependency-path: src/frontend/yarn.lock
+
+      - name: Restore the frontend cache
+        uses: actions/cache@v3
+        id: cache-install
+        with:
+          path: src/frontend/
+          key: install-front-${{ hashFiles('src/frontend/**/yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        run: cd src/frontend/ && yarn install --frozen-lockfile
+
+      - name: Cache install frontend
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: src/frontend/
+          key: install-front-${{ hashFiles('src/frontend/**/yarn.lock') }}
+
+  build-front:
+    runs-on: ubuntu-latest
+    needs: install-front
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore the frontend cache
+        uses: actions/cache@v3
+        id: cache-install
+        with:
+          path: src/frontend/
+          key: install-front-${{ hashFiles('src/frontend/**/yarn.lock') }}
+
+      - name: Build CI App
+        run: cd src/frontend/ && yarn ci:build
+
+      - name: Cache build frontend
+        uses: actions/cache@v3
+        with:
+          path: src/frontend/
+          key: build-front-${{ github.run_id }}
+        
+  test-front:
+    runs-on: ubuntu-latest
+    needs: install-front
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore the frontend cache
+        uses: actions/cache@v3
+        id: cache-install
+        with:
+          path: src/frontend/
+          key: install-front-${{ hashFiles('src/frontend/**/yarn.lock') }}
 
       - name: Test App
-        run: yarn app:test
+        run: cd src/frontend/ && yarn app:test
 
   lint-front:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src/frontend/
+    needs: install-front
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Restore the frontend cache
+        uses: actions/cache@v3
+        id: cache-install
         with:
-          node-version: '18.x'
-          cache: 'yarn'
-          cache-dependency-path: src/frontend/yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+          path: src/frontend/
+          key: install-front-${{ hashFiles('src/frontend/**/yarn.lock') }}
         
       - name: Check linting
-        run: yarn lint
+        run: cd src/frontend/ && yarn lint
 
   test-e2e:
     runs-on: ubuntu-latest
-    needs: build-mails
+    needs: [build-mails, build-front]
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -120,6 +163,13 @@ jobs:
         with:
           name: mails-templates
           path: src/backend/core/templates/mail
+
+      - name: Restore the build cache
+        uses: actions/cache@v3
+        id: cache-build
+        with:
+          path: src/frontend/
+          key: build-front-${{ github.run_id }}
     
       - name: Build and Start Docker Servers
         env:
@@ -137,21 +187,8 @@ jobs:
         run: |
           make demo FLUSH_ARGS='--no-input'
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          cache: 'yarn'
-          cache-dependency-path: src/frontend/yarn.lock
-
-      - name: Install dependencies
-        run: cd src/frontend/ && yarn install --frozen-lockfile
-
       - name: Install Playwright Browsers
         run: cd src/frontend/apps/e2e && yarn install
-
-      - name: Build CI App
-        run: cd src/frontend/ && yarn ci:build
 
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test

--- a/src/frontend/apps/e2e/__tests__/app-desk/member-delete.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/member-delete.spec.ts
@@ -35,7 +35,7 @@ test.describe('Members Delete', () => {
     page,
     browserName,
   }) => {
-    await createTeam(page, 'member-delete-1', browserName, 1);
+    await createTeam(page, 'member-delete-2', browserName, 1);
 
     await addNewMember(page, 0, 'Owner');
 
@@ -59,7 +59,7 @@ test.describe('Members Delete', () => {
   });
 
   test('it cannot delete owner member', async ({ page, browserName }) => {
-    await createTeam(page, 'member-delete-1', browserName, 1);
+    await createTeam(page, 'member-delete-3', browserName, 1);
 
     const username = await addNewMember(page, 0, 'Owner');
 
@@ -80,7 +80,7 @@ test.describe('Members Delete', () => {
   });
 
   test('it deletes admin member', async ({ page, browserName }) => {
-    await createTeam(page, 'member-delete-1', browserName, 1);
+    await createTeam(page, 'member-delete-4', browserName, 1);
 
     const username = await addNewMember(page, 0, 'Admin');
 
@@ -105,7 +105,7 @@ test.describe('Members Delete', () => {
     page,
     browserName,
   }) => {
-    await createTeam(page, 'member-delete-1', browserName, 1);
+    await createTeam(page, 'member-delete-5', browserName, 1);
 
     const username = await addNewMember(page, 0, 'Owner');
 
@@ -132,7 +132,7 @@ test.describe('Members Delete', () => {
   });
 
   test('it deletes admin member when admin', async ({ page, browserName }) => {
-    await createTeam(page, 'member-delete-1', browserName, 1);
+    await createTeam(page, 'member-delete-6', browserName, 1);
 
     // To not be the only owner
     await addNewMember(page, 0, 'Owner');

--- a/src/frontend/apps/e2e/__tests__/app-desk/teams-delete.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/teams-delete.spec.ts
@@ -12,7 +12,7 @@ test.describe('Teams Delete', () => {
     page,
     browserName,
   }) => {
-    await createTeam(page, 'team-update-name', browserName, 1);
+    await createTeam(page, 'team-update-name-1', browserName, 1);
 
     await page.getByLabel(`Open the team options`).click();
     await page.getByRole('button', { name: `Delete the team` }).click();
@@ -27,7 +27,7 @@ test.describe('Teams Delete', () => {
     page,
     browserName,
   }) => {
-    await createTeam(page, 'team-update-name', browserName, 1);
+    await createTeam(page, 'team-update-name-2', browserName, 1);
 
     await addNewMember(page, 0, 'Owner');
 
@@ -55,7 +55,7 @@ test.describe('Teams Delete', () => {
     page,
     browserName,
   }) => {
-    await createTeam(page, 'team-update-name', browserName, 1);
+    await createTeam(page, 'team-update-name-3', browserName, 1);
 
     await addNewMember(page, 0, 'Owner');
 

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -46,12 +46,6 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'], locale: 'en-US' },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'], locale: 'en-US' },
-    },
-
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'], locale: 'en-US' },


### PR DESCRIPTION
## Purpose

To improve the speed of the CI, we cache the frontend install. 
**It will even be reused between pull request until the yarn.lock has a change.**

We cache as well the desk build app, in another cache, this cache persist only per workflow. 
It will increase the speed if we have e2e flaky tests and that we have to relaunch the e2e job.

⚠️ Firefox e2e tests are often flaky, Firefox is about 3% of the browser used on the web, we remove the e2e support for the moment: https://gs.statcounter.com/browser-market-share

## Archi

![image](https://github.com/numerique-gouv/people/assets/25994652/29f127fc-18a5-4a22-995d-5993a0eb6f7a)

## Opti

**From 1m54s to 10 seconds.**

![image](https://github.com/numerique-gouv/people/assets/25994652/3cf4ddaf-3e8b-4d9c-9eec-7540d378e1b6)

![image](https://github.com/numerique-gouv/people/assets/25994652/2a09d11d-8ca3-4544-bccb-09ab7e275842)

