### PR TITLE
Update Github Actions version (Node.js 16 is deprecated)

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'pull_request' # Makes sense only for pull requests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
       - name: show
@@ -39,7 +39,7 @@ jobs:
       github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             fetch-depth: 0
       - name: Check that the CHANGELOG has been modified in the current branch
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check CHANGELOG max line length
         run: |
           max_line_length=$(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com" | wc -L)
@@ -200,7 +200,7 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -214,7 +214,7 @@ jobs:
         working-directory: src/mail
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
@@ -238,9 +238,9 @@ jobs:
         working-directory: src/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install development dependencies
@@ -284,7 +284,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create writable /data
         run: |
           sudo mkdir -p /data/media && \
@@ -295,7 +295,7 @@ jobs:
           name: mails-templates
           path: src/backend/core/templates/mail
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install development dependencies
@@ -313,7 +313,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Install gettext (required to make messages)
         run: |
@@ -321,7 +321,7 @@ jobs:
           sudo apt-get install -y gettext
       
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
## Purpose

Node.js 16 actions are deprecated, update them.


## Proposal

<img width="790" alt="Capture d’écran 2024-04-02 à 15 18 41" src="https://github.com/numerique-gouv/people/assets/45729124/c4c49a5e-8e76-4edb-a7f0-535dc72c5a35">

