### PR TITLE
🔧(compose) stop forcing platform for Keycloak PostgreSQL image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,6 @@ services:
 
   kc_postgresql:
       image: postgres:14.3
-      platform: linux/amd64
       ports:
         - "5433:5432"
       env_file:


### PR DESCRIPTION
Forcing `platform: linux/amd64` for the PostgreSQL image causes compatibility issues and performance degradation on Mac ARM chips (M1/M2). Removing the platform specification allows Docker to select the appropriate architecture automatically, ensuring better performance and compatibility.

Any linux user could test this changes, to make sure it doesn't introduce any regression?
@sampaccoud why the platform was pinned? 