### PR TITLE
♻️(mails) link email from current site

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -12,6 +12,7 @@ from logging import getLogger
 from django.conf import settings
 from django.contrib.auth import models as auth_models
 from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.sites.models import Site
 from django.core import exceptions, mail, validators
 from django.db import models, transaction
 from django.template.loader import render_to_string
@@ -660,6 +661,7 @@ class Invitation(BaseModel):
             with override(self.issuer.language):
                 template_vars = {
                     "title": _("Invitation to join Desk!"),
+                    "site": Site.objects.get_current(),
                 }
                 msg_html = render_to_string("mail/html/invitation.html", template_vars)
                 msg_plain = render_to_string("mail/text/invitation.txt", template_vars)

--- a/src/backend/core/tests/test_models_invitations.py
+++ b/src/backend/core/tests/test_models_invitations.py
@@ -264,6 +264,7 @@ def test_models_team_invitations_email():
 
     email_content = " ".join(email.body.split())
     assert "Invitation to join Desk!" in email_content
+    assert "[//example.com]" in email_content
 
 
 @mock.patch(

--- a/src/mail/mjml/invitation.mjml
+++ b/src/mail/mjml/invitation.mjml
@@ -35,7 +35,7 @@
               <li>{% trans "Facilitate exchanges and communication with our messaging and group discussion tools."%}</li>
             </ul>
           </mj-text>
-          <mj-button href="https://desk-staging.beta.numerique.gouv.fr/" background-color="#000091" color="white" padding-bottom="30px">
+          <mj-button href="//{{site.domain}}" background-color="#000091" color="white" padding-bottom="30px">
             {% trans "Visit Equipes"%}
           </mj-button>
           <mj-text>{% trans "We are confident that Equipes will help you increase efficiency and productivity while strengthening the bond among members." %}</mj-text>

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -9,9 +9,9 @@
   },
   "private": true,
   "scripts": {
-    "build-mjml-to-html": "./bin/mjml-to-html",
-    "build-html-to-plain-text": "./bin/html-to-plain-text",
-    "build": "yarn build-mjml-to-html; yarn build-html-to-plain-text;"
+    "build-mjml-to-html": "bash ./bin/mjml-to-html",
+    "build-html-to-plain-text": "bash ./bin/html-to-plain-text",
+    "build": "yarn build-mjml-to-html && yarn build-html-to-plain-text"
   },
   "volta": {
     "node": "16.15.1"


### PR DESCRIPTION
## Purpose

The link in the email was pointing on the staging website. We now use a variable to target the current site setup in the database.
Based on this PR: https://github.com/numerique-gouv/impress/pull/56

## Proposal

- [x] 🧑‍💻(mail) make commands windows friendly
- [x] ♻️(mails) link email from current site

## How to do 

![image](https://github.com/numerique-gouv/people/assets/25994652/ebcf3340-b217-4f43-80ff-9fb6805102e0)
