### PR TITLE
🚧(app-regie) use mail domain slug for mail-domains navigation and requests

### DIFF
--- a/src/backend/mailbox_manager/admin.py
+++ b/src/backend/mailbox_manager/admin.py
@@ -14,9 +14,10 @@ class MailDomainAdmin(admin.ModelAdmin):
         "name",
         "created_at",
         "updated_at",
+        "slug",
     )
     search_fields = ("name",)
-    readonly_fields = ["created_at"]
+    readonly_fields = ["created_at", "slug"]
 
 
 @admin.register(models.MailDomainAccess)

--- a/src/backend/mailbox_manager/api/serializers.py
+++ b/src/backend/mailbox_manager/api/serializers.py
@@ -26,6 +26,12 @@ class MailDomainSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
+        read_only_fields = [
+            "id",
+            "slug",
+            "created_at",
+            "updated_at",
+        ]
 
 
 class MailDomainAccessSerializer(serializers.ModelSerializer):

--- a/src/backend/mailbox_manager/api/serializers.py
+++ b/src/backend/mailbox_manager/api/serializers.py
@@ -22,6 +22,7 @@ class MailDomainSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "name",
+            "slug",
             "created_at",
             "updated_at",
         ]

--- a/src/backend/mailbox_manager/models.py
+++ b/src/backend/mailbox_manager/models.py
@@ -28,9 +28,13 @@ class MailDomain(BaseModel):
         return self.name
 
     def save(self, *args, **kwargs):
-        if not self.slug:
-            self.slug = slugify(self.name)
+        """Override save function to compute the slug."""
+        self.slug = self.get_slug()
         return super().save(*args, **kwargs)
+
+    def get_slug(self):
+        """Compute slug value from name."""
+        return slugify(self.name)
 
     def get_abilities(self, user):
         """

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
@@ -66,6 +66,7 @@ def test_api_mail_domains__retrieve_authenticated_related():
     assert response.json() == {
         "id": str(domain.id),
         "name": domain.name,
+        "slug": domain.slug,
         "created_at": domain.created_at.isoformat().replace("+00:00", "Z"),
         "updated_at": domain.updated_at.isoformat().replace("+00:00", "Z"),
     }

--- a/src/backend/mailbox_manager/tests/test_models_maildomain.py
+++ b/src/backend/mailbox_manager/tests/test_models_maildomain.py
@@ -3,13 +3,13 @@ Unit tests for the MailDomain model
 """
 
 from django.core.exceptions import ValidationError
+from django.utils.text import slugify
 
 import pytest
 
 from mailbox_manager import factories
 
 pytestmark = pytest.mark.django_db
-
 
 # NAME FIELD
 
@@ -24,3 +24,11 @@ def test_models_mail_domain__domain_name_should_not_be_null():
     """The domain name field should not be null."""
     with pytest.raises(ValidationError, match="This field cannot be null."):
         factories.MailDomainFactory(name=None)
+
+
+def test_models_mail_domain__slug_inferred_from_name():
+    """Passed slug is ignored. Slug is automatically generated from name."""
+
+    name = "N3w_D0main-Name$.com"
+    domain = factories.MailDomainFactory(name=name, slug="something else")
+    assert domain.slug == slugify(name)

--- a/src/frontend/apps/desk/src/features/mail-domains/api/useCreateMailbox.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/api/useCreateMailbox.tsx
@@ -1,5 +1,3 @@
-import { UUID } from 'crypto';
-
 import {
   UseMutationOptions,
   useMutation,
@@ -16,14 +14,14 @@ export interface CreateMailboxParams {
   local_part: string;
   secondary_email: string;
   phone_number: string;
-  mailDomainId: UUID;
+  mailDomainSlug: string;
 }
 
 export const createMailbox = async ({
-  mailDomainId,
+  mailDomainSlug,
   ...data
 }: CreateMailboxParams): Promise<void> => {
-  const response = await fetchAPI(`mail-domains/${mailDomainId}/mailboxes/`, {
+  const response = await fetchAPI(`mail-domains/${mailDomainSlug}/mailboxes/`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
@@ -37,7 +35,7 @@ export const createMailbox = async ({
   }
 };
 
-type UseCreateMailboxParams = { domainId: UUID } & UseMutationOptions<
+type UseCreateMailboxParams = { mailDomainSlug: string } & UseMutationOptions<
   void,
   APIError,
   CreateMailboxParams
@@ -49,7 +47,10 @@ export function useCreateMailbox(options: UseCreateMailboxParams) {
     mutationFn: createMailbox,
     onSuccess: (data, variables, context) => {
       void queryClient.invalidateQueries({
-        queryKey: [KEY_LIST_MAILBOX, { id: variables.mailDomainId }],
+        queryKey: [
+          KEY_LIST_MAILBOX,
+          { mailDomainSlug: variables.mailDomainSlug },
+        ],
       });
       if (options?.onSuccess) {
         options.onSuccess(data, variables, context);

--- a/src/frontend/apps/desk/src/features/mail-domains/api/useMailDomain.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/api/useMailDomain.tsx
@@ -5,19 +5,19 @@ import { APIError, errorCauses, fetchAPI } from '@/api';
 import { MailDomain } from '../types';
 
 export type MailDomainParams = {
-  id: string;
+  slug: string;
 };
 
 type MailDomainResponse = MailDomain;
 
 export const getMailDomain = async ({
-  id,
+  slug,
 }: MailDomainParams): Promise<MailDomainResponse> => {
-  const response = await fetchAPI(`mail-domains/${id}`);
+  const response = await fetchAPI(`mail-domains/${slug}`);
 
   if (!response.ok) {
     throw new APIError(
-      `Failed to get the mail domain ${id}`,
+      `Failed to get the mail domain ${slug}`,
       await errorCauses(response),
     );
   }

--- a/src/frontend/apps/desk/src/features/mail-domains/api/useMailboxes.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/api/useMailboxes.tsx
@@ -5,7 +5,7 @@ import { APIError, APIList, errorCauses, fetchAPI } from '@/api';
 import { MailDomainMailbox } from '../types';
 
 export type MailDomainMailboxesParams = {
-  id: string;
+  mailDomainSlug: string;
   page: number;
   ordering?: string;
 };
@@ -13,11 +13,11 @@ export type MailDomainMailboxesParams = {
 type MailDomainMailboxesResponse = APIList<MailDomainMailbox>;
 
 export const getMailDomainMailboxes = async ({
-  id,
+  mailDomainSlug,
   page,
   ordering,
 }: MailDomainMailboxesParams): Promise<MailDomainMailboxesResponse> => {
-  let url = `mail-domains/${id}/mailboxes/?page=${page}`;
+  let url = `mail-domains/${mailDomainSlug}/mailboxes/?page=${page}`;
 
   if (ordering) {
     url += '&ordering=' + ordering;
@@ -27,7 +27,7 @@ export const getMailDomainMailboxes = async ({
 
   if (!response.ok) {
     throw new APIError(
-      `Failed to get the mailboxes of mail domain ${id}`,
+      `Failed to get the mailboxes of mail domain ${mailDomainSlug}`,
       await errorCauses(response),
     );
   }

--- a/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
@@ -46,9 +46,10 @@ function formatSortModel(
 
 export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
   const [sortModel, setSortModel] = useState<SortModel>([]);
-  const { t } = useTranslation();
   const [isCreateMailboxFormVisible, setIsCreateMailboxFormVisible] =
     useState(false);
+
+  const { t } = useTranslation();
 
   const pagination = usePagination({
     defaultPage: 1,
@@ -59,7 +60,7 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
   const ordering = sortModel.length ? formatSortModel(sortModel[0]) : undefined;
 
   const { data, isLoading, error } = useMailboxes({
-    id: mailDomain.id,
+    mailDomainSlug: mailDomain.slug,
     page,
     ordering,
   });

--- a/src/frontend/apps/desk/src/features/mail-domains/components/forms/CreateMailboxForm.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/components/forms/CreateMailboxForm.tsx
@@ -60,7 +60,7 @@ export const CreateMailboxForm = ({
   });
 
   const { mutate: createMailbox, ...queryState } = useCreateMailbox({
-    domainId: mailDomain.id,
+    mailDomainSlug: mailDomain.slug,
     onSuccess: () => {
       toast(t('Mailbox created!'), VariantType.SUCCESS, {
         duration: 4000,
@@ -75,7 +75,7 @@ export const CreateMailboxForm = ({
   const onSubmitCallback = (event: React.FormEvent) => {
     event.preventDefault();
     void methods.handleSubmit((data) =>
-      createMailbox({ ...data, mailDomainId: mailDomain.id }),
+      createMailbox({ ...data, mailDomainSlug: mailDomain.slug }),
     )();
   };
 

--- a/src/frontend/apps/desk/src/features/mail-domains/components/panel/PanelItem.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/components/panel/PanelItem.tsx
@@ -15,10 +15,10 @@ export const PanelMailDomains = ({ mailDomain }: MailDomainProps) => {
   const { colorsTokens } = useCunninghamTheme();
   const { t } = useTranslation();
   const {
-    query: { id },
+    query: { slug },
   } = useRouter();
 
-  const isActive = mailDomain.id === id;
+  const isActive = mailDomain.slug === slug;
 
   const activeStyle = `
     border-right: 4px solid ${colorsTokens()['primary-600']};
@@ -51,7 +51,7 @@ export const PanelMailDomains = ({ mailDomain }: MailDomainProps) => {
     >
       <StyledLink
         className="p-s pt-t pb-t"
-        href={`/mail-domains/${mailDomain.id}`}
+        href={`/mail-domains/${mailDomain.slug}`}
       >
         <Box $align="center" $direction="row" $gap="0.5rem">
           <IconMailDomains

--- a/src/frontend/apps/desk/src/features/mail-domains/types.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/types.tsx
@@ -5,6 +5,7 @@ export interface MailDomain {
   name: string;
   created_at: string;
   updated_at: string;
+  slug: string;
 }
 
 export interface MailDomainMailbox {

--- a/src/frontend/apps/desk/src/pages/mail-domains/[slug].tsx
+++ b/src/frontend/apps/desk/src/pages/mail-domains/[slug].tsx
@@ -12,11 +12,11 @@ import { NextPageWithLayout } from '@/types/next';
 const Page: NextPageWithLayout = () => {
   const router = useRouter();
 
-  if (router?.query?.id && typeof router.query.id !== 'string') {
-    throw new Error('Invalid mail domain id');
+  if (router?.query?.slug && typeof router.query.slug !== 'string') {
+    throw new Error('Invalid mail domain slug');
   }
 
-  const { id } = router.query;
+  const { slug } = router.query;
 
   const navigate = useNavigate();
 
@@ -25,7 +25,7 @@ const Page: NextPageWithLayout = () => {
     error: error,
     isError,
     isLoading: isLoading,
-  } = useMailDomain({ id: String(id) });
+  } = useMailDomain({ slug: String(slug) });
 
   if (error?.status === 404) {
     navigate.replace(`/404`);

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain-create-mailbox.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain-create-mailbox.spec.ts
@@ -14,24 +14,28 @@ const mailDomainsFixtures: MailDomain[] = [
     id: '456ac6ca-0402-4615-8005-69bc1efde43f',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'domainfr',
   },
   {
     name: 'mails.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43e',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'mailsfr',
   },
   {
     name: 'versailles.net',
     id: '456ac6ca-0402-4615-8005-69bc1efde43g',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'versaillesnet',
   },
   {
     name: 'paris.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43h',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'parisfr',
   },
 ];
 
@@ -77,16 +81,13 @@ test.describe('Mail domain create mailbox', () => {
           },
         });
       });
+      await page.route('**/api/v1.0/mail-domains/domainfr', async (route) => {
+        await route.fulfill({
+          json: mailDomainDomainFrFixture,
+        });
+      });
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f',
-        async (route) => {
-          await route.fulfill({
-            json: mailDomainDomainFrFixture,
-          });
-        },
-      );
-      await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1**',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=1**',
         async (route) => {
           await route.fulfill({
             json: {
@@ -101,7 +102,7 @@ test.describe('Mail domain create mailbox', () => {
       );
 
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1**',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=1**',
         async (route) => {
           await route.fulfill({
             json: {
@@ -115,7 +116,7 @@ test.describe('Mail domain create mailbox', () => {
       );
 
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/',
         (route) => {
           if (route.request().method() === 'POST') {
             void route.fulfill({
@@ -131,11 +132,7 @@ test.describe('Mail domain create mailbox', () => {
     let isCreateMailboxRequestSentWithExpectedPayload = false;
     page.on('request', (request) => {
       if (
-        request
-          .url()
-          .includes(
-            '/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/',
-          ) &&
+        request.url().includes('/mail-domains/domainfr/mailboxes/') &&
         request.method() === 'POST'
       ) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -221,16 +218,13 @@ test.describe('Mail domain create mailbox', () => {
           },
         });
       });
+      await page.route('**/api/v1.0/mail-domains/domainfr', async (route) => {
+        await route.fulfill({
+          json: mailDomainDomainFrFixture,
+        });
+      });
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f',
-        async (route) => {
-          await route.fulfill({
-            json: mailDomainDomainFrFixture,
-          });
-        },
-      );
-      await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1**',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=1**',
         async (route) => {
           await route.fulfill({
             json: {
@@ -248,11 +242,7 @@ test.describe('Mail domain create mailbox', () => {
     let isCreateMailboxRequestSent = false;
     page.on('request', (request) => {
       if (
-        request
-          .url()
-          .includes(
-            '/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/',
-          ) &&
+        request.url().includes('/mail-domains/domainfr/mailboxes/') &&
         request.method() === 'POST'
       ) {
         isCreateMailboxRequestSent = true;

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -11,24 +11,28 @@ const mailDomainsFixtures: MailDomain[] = [
     id: '456ac6ca-0402-4615-8005-69bc1efde43f',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'domainfr',
   },
   {
     name: 'mails.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43e',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'mailsfr',
   },
   {
     name: 'versailles.net',
     id: '456ac6ca-0402-4615-8005-69bc1efde43g',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'versaillesnet',
   },
   {
     name: 'paris.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43h',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'parisfr',
   },
 ];
 
@@ -72,7 +76,7 @@ test.describe('Mail domain', () => {
   }) => {
     const interceptApiCalls = async () => {
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=1',
         async (route) => {
           await route.fulfill({
             json: {
@@ -85,14 +89,11 @@ test.describe('Mail domain', () => {
         },
       );
 
-      await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f**',
-        async (route) => {
-          await route.fulfill({
-            json: mailDomainDomainFrFixture,
-          });
-        },
-      );
+      await page.route('**/api/v1.0/mail-domains/domainfr**', async (route) => {
+        await route.fulfill({
+          json: mailDomainDomainFrFixture,
+        });
+      });
       await page.route('**/api/v1.0/mail-domains/?page=*', async (route) => {
         await route.fulfill({
           json: {
@@ -112,9 +113,7 @@ test.describe('Mail domain', () => {
     await expect(page).toHaveURL(/mail-domains/);
 
     await page.getByRole('listbox').first().getByText('domain.fr').click();
-    await expect(page).toHaveURL(
-      /mail-domains\/456ac6ca-0402-4615-8005-69bc1efde43f/,
-    );
+    await expect(page).toHaveURL(/mail-domains\/domainfr/);
 
     await expect(
       page.getByRole('heading', { name: /domain\.fr/ }).first(),
@@ -151,23 +150,20 @@ test.describe('Mail domain', () => {
           },
         });
       });
+      await page.route('**/api/v1.0/mail-domains/domainfr', async (route) => {
+        await route.fulfill({
+          json: mailDomainDomainFrFixture,
+        });
+      });
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f',
-        async (route) => {
-          await route.fulfill({
-            json: mailDomainDomainFrFixture,
-          });
-        },
-      );
-      await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1**',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=1**',
         async (route) => {
           await route.fulfill({
             json: {
               count:
                 mailboxesFixtures.domainFr.page1.length +
                 mailboxesFixtures.domainFr.page2.length,
-              next: 'http://localhost:8071/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=2',
+              next: 'http://localhost:8071/api/v1.0/mail-domains/domainfr/mailboxes/?page=2',
               previous: null,
               results: mailboxesFixtures.domainFr.page1,
             },
@@ -175,7 +171,7 @@ test.describe('Mail domain', () => {
         },
       );
       await page.route(
-        '**/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=2**',
+        '**/api/v1.0/mail-domains/domainfr/mailboxes/?page=2**',
         async (route) => {
           await route.fulfill({
             json: {
@@ -184,7 +180,7 @@ test.describe('Mail domain', () => {
                 mailboxesFixtures.domainFr.page2.length,
               next: null,
               previous:
-                'http://localhost:8071/api/v1.0/mail-domains/456ac6ca-0402-4615-8005-69bc1efde43f/mailboxes/?page=1',
+                'http://localhost:8071/api/v1.0/mail-domains/domainfr/mailboxes/?page=1',
               results: mailboxesFixtures.domainFr.page2,
             },
           });
@@ -199,9 +195,7 @@ test.describe('Mail domain', () => {
     await expect(page).toHaveURL(/mail-domains/);
 
     await page.getByRole('listbox').first().getByText('domain.fr').click();
-    await expect(page).toHaveURL(
-      /mail-domains\/456ac6ca-0402-4615-8005-69bc1efde43f/,
-    );
+    await expect(page).toHaveURL(/mail-domains\/domainfr/);
 
     await expect(
       page.getByRole('heading', { name: 'domain.fr' }),

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
@@ -10,24 +10,28 @@ const mailDomainsFixtures: MailDomain[] = [
     id: '456ac6ca-0402-4615-8005-69bc1efde43f',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'domainfr',
   },
   {
     name: 'mails.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43e',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'mailsfr',
   },
   {
     name: 'versailles.net',
     id: '456ac6ca-0402-4615-8005-69bc1efde43g',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'versaillesnet',
   },
   {
     name: 'paris.fr',
     id: '456ac6ca-0402-4615-8005-69bc1efde43h',
     created_at: currentDateIso,
     updated_at: currentDateIso,
+    slug: 'parisfr',
   },
 ];
 


### PR DESCRIPTION
# Stop using mailDomain.id in frontend navigation and requests to the backend. Instead, use mailDomain.url as a slug.


## A meaningful URL, easy to memorize for the user consulting a specific mail domain view. 
With this change, instead of providing a UUID in the frontend application URL, we use the slug of a mail domain.
As a result, a URL that used to have the format `http://localhost:3000/mail-domains/6bbd8081-563a-4c5a-ae02-2785d18f2480` will look like `http://localhost:3000/mail-domains/domainfr`.

## Changes in the code
Each navigation button supposed to redirect to the view of a specific mail domain will embed the slug of the mail domain instead of its id. Also, every http request sent to the django API on the api/mail-domains/ path related to a specific domain and its mailboxes will use the mail domain slug instead of its id (as introduced in commit b4bafb6efbcfae4ed8a116061ee471a27737c41e).
