### PR TITLE
🚨(backend) fix warning SSL

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'fix/warning-backend'
     tags:
       - 'v*'
   pull_request:

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -515,6 +515,12 @@ class Production(Base):
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_HSTS_SECONDS = values.IntegerValue(
+        default=31536000, environ_name="SECURE_HSTS_SECONDS"
+    )
+    SECURE_SSL_REDIRECT = values.BooleanValue(
+        default=True, environ_name="SECURE_SSL_REDIRECT"
+    )
 
     # SECURE_PROXY_SSL_HEADER allows to fix the scheme in Django's HttpRequest
     # object when your application is behind a reverse proxy.

--- a/src/frontend/apps/desk/src/features/header/Header.tsx
+++ b/src/frontend/apps/desk/src/features/header/Header.tsx
@@ -57,7 +57,7 @@ export const Header = () => {
             <Box $align="center" $gap="1rem" $direction="row">
               <Image priority src={IconApplication} alt={t('Equipes Logo')} />
               <Text $margin="none" as="h2" $theme="primary">
-                {t('Equipes')}
+                {t('Equipes Test')}
               </Text>
             </Box>
           </Box>

--- a/src/helm/desk/templates/_helpers.tpl
+++ b/src/helm/desk/templates/_helpers.tpl
@@ -125,6 +125,7 @@ tcpSocket:
 httpGet:
   path: {{ .path }}
   port: {{ .targetPort }}
+  scheme: {{ .scheme | default "HTTP" }}
 {{- end }}
 initialDelaySeconds: {{ .initialDelaySeconds | eq nil | ternary 0 .initialDelaySeconds }}
 timeoutSeconds: {{ .timeoutSeconds | eq nil | ternary 1 .timeoutSeconds }}

--- a/src/helm/desk/templates/secrets.yaml
+++ b/src/helm/desk/templates/secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend
+  namespace: {{ .Release.Namespace | quote }}
+stringData:
+  DJANGO_SUPERUSER_PASSWORD: {{ .Values.djangoSuperUserPass }}
+  DJANGO_SECRET_KEY: {{ .Values.djangoSecretKey }}
+  OIDC_RP_CLIENT_ID: {{ .Values.oidc.clientId }}
+  OIDC_RP_CLIENT_SECRET: {{ .Values.oidc.clientSecret }}

--- a/src/helm/env.d/staging/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.desk.yaml.gotmpl
@@ -92,6 +92,16 @@ backend:
       - python manage.py createsuperuser --admin_email $DJANGO_SUPERUSER_EMAIL --password $DJANGO_SUPERUSER_PASSWORD
     restartPolicy: Never
 
+  probes:
+    liveness:
+      path: /__heartbeat__
+      scheme: HTTPS
+      initialDelaySeconds: 10
+    readiness:
+      path: /__lbheartbeat__
+      scheme: HTTPS
+      initialDelaySeconds: 10
+
 frontend:
   image:
     repository: lasuite/people-frontend

--- a/src/helm/env.d/staging/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.desk.yaml.gotmpl
@@ -1,7 +1,7 @@
 image:
   repository: lasuite/people-backend
   pullPolicy: Always
-  tag: "main"
+  tag: "fix-warning-backend"
 
 backend:
   migrateJobAnnotations:
@@ -96,7 +96,7 @@ frontend:
   image:
     repository: lasuite/people-frontend
     pullPolicy: Always
-    tag: "main"
+    tag: "fix-warning-backend"
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Purpose

The logs were showing a warning about the SSL:
-  You have not set a value for the SECURE_HSTS_SECONDS setting.
- Your SECURE_SSL_REDIRECT setting is not set to True.

This commit fixes the warning by setting the SECURE_HSTS_SECONDS to 31536000 and SECURE_SSL_REDIRECT to True.

```
security.W004: You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
security.W008: Your SECURE_SSL_REDIRECT setting is not set to True. Unless your site should be available over both SSL and non-SSL connections, you may want to either set this setting True or configure a load balancer or reverse-proxy server to redirect all connections to HTTPS.
```

## Demo

![image](https://github.com/numerique-gouv/people/assets/25994652/e19de324-e84d-4de5-9459-6e4e60a43c1e)



