### PR TITLE
🏷️(frontend) adapt ordering name

### DIFF
--- a/src/frontend/apps/desk/src/features/teams/member-management/__tests__/MemberGrid.test.tsx
+++ b/src/frontend/apps/desk/src/features/teams/member-management/__tests__/MemberGrid.test.tsx
@@ -221,10 +221,10 @@ describe('MemberGrid', () => {
   });
 
   it.each([
-    ['name', 'Names'],
-    ['email', 'Emails'],
-    ['role', 'Roles'],
-  ])('checks the sorting', async (ordering, header_name) => {
+    ['Names', 'user__name'],
+    ['Emails', 'user__email'],
+    ['Roles', 'role'],
+  ])('checks the sorting of %s', async (header_name, ordering) => {
     const mockedData = [
       {
         id: '123',

--- a/src/frontend/apps/desk/src/features/teams/member-management/components/MemberGrid.tsx
+++ b/src/frontend/apps/desk/src/features/teams/member-management/components/MemberGrid.tsx
@@ -30,8 +30,8 @@ type SortModelItem = {
 };
 
 const defaultOrderingMapping: Record<string, string> = {
-  'user.name': 'name',
-  'user.email': 'email',
+  'user.name': 'user__name',
+  'user.email': 'user__email',
   localizedRole: 'role',
 };
 


### PR DESCRIPTION
## Purpose

A recent change on the backend side ([#2ec29](https://github.com/numerique-gouv/people/commit/2ec292b)) changes the naming ordering params with a prefix "user__". 
We adapt the ordering name in the frontend to match the backend in order to have the sorting working.

## Proposal

- [x] fix sorting
- [x] fix flickering on sorting

## Demo

[scrnli_6_28_2024_10-16-13 AM.webm](https://github.com/numerique-gouv/people/assets/25994652/50d3f633-4a46-43df-86ec-43e72680f3d9)



