### PR TITLE
Feature/html lang

### DIFF
--- a/src/frontend/apps/desk/src/i18n/initI18n.ts
+++ b/src/frontend/apps/desk/src/i18n/initI18n.ts
@@ -16,6 +16,11 @@ i18n
     preload: LANGUAGES_ALLOWED,
     nsSeparator: '||',
   })
+  .then(() => {
+    if (typeof window !== 'undefined') {
+      document.documentElement.lang = i18n.language;
+    }
+  })
   .catch(() => {
     throw new Error('i18n initialization failed');
   });
@@ -24,6 +29,7 @@ i18n
 i18n.on('languageChanged', (lng) => {
   if (typeof window !== 'undefined') {
     localStorage.setItem(LANGUAGE_LOCAL_STORAGE, lng);
+    document.documentElement.lang = lng;
   }
 });
 

--- a/src/frontend/apps/desk/src/pages/_document.tsx
+++ b/src/frontend/apps/desk/src/pages/_document.tsx
@@ -4,7 +4,7 @@ import '@/i18n/initI18n';
 
 export default function RootLayout() {
   return (
-    <Html lang="en">
+    <Html>
       <Head />
       <body suppressHydrationWarning={process.env.NODE_ENV === 'development'}>
         <Main />

--- a/src/frontend/apps/e2e/__tests__/app-desk/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/language.spec.ts
@@ -26,4 +26,20 @@ test.describe('Language', () => {
       }),
     ).toBeVisible();
   });
+
+  // test('checks lang attribute of html tag has same default value as defined');
+  test('checks lang attribute of html tag updates when user changes language', async ({
+    page,
+  }) => {
+    const header = page.locator('header').first();
+
+    await header.getByRole('combobox').getByText('EN').click();
+    const html = page.locator('html');
+
+    await expect(html).toHaveAttribute('lang', 'en');
+
+    await header.getByRole('option', { name: 'FR' }).click();
+
+    await expect(html).toHaveAttribute('lang', 'fr');
+  });
 });

--- a/src/frontend/apps/e2e/__tests__/app-desk/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/language.spec.ts
@@ -1,13 +1,14 @@
-import { expect, test } from '@playwright/test';
+import { BrowserContext, Page, expect, test } from '@playwright/test';
+import { LANGUAGES_ALLOWED } from 'app-desk/src/i18n/conf';
 
 import { keyCloakSignIn } from './common';
 
-test.beforeEach(async ({ page, browserName }) => {
-  await page.goto('/');
-  await keyCloakSignIn(page, browserName);
-});
-
 test.describe('Language', () => {
+  test.beforeEach(async ({ page, browserName }) => {
+    await page.goto('/');
+    await keyCloakSignIn(page, browserName);
+  });
+
   test('checks the language picker', async ({ page }) => {
     await expect(
       page.getByRole('button', {
@@ -27,7 +28,6 @@ test.describe('Language', () => {
     ).toBeVisible();
   });
 
-  // test('checks lang attribute of html tag has same default value as defined');
   test('checks lang attribute of html tag updates when user changes language', async ({
     page,
   }) => {
@@ -41,5 +41,25 @@ test.describe('Language', () => {
     await header.getByRole('option', { name: 'FR' }).click();
 
     await expect(html).toHaveAttribute('lang', 'fr');
+  });
+});
+
+test.describe('Default language', () => {
+  LANGUAGES_ALLOWED.forEach((language) => {
+    test(`checks lang attribute of html tag has right value by default for ${language} language`, async ({
+      browser,
+      browserName,
+    }) => {
+      const context: BrowserContext = await browser.newContext({
+        locale: language,
+      });
+
+      const page: Page = await context.newPage();
+
+      await page.goto('/');
+      await keyCloakSignIn(page, browserName);
+
+      await expect(page.locator('html')).toHaveAttribute('lang', language);
+    });
   });
 });


### PR DESCRIPTION
## Purpose

We noticed that the `lang` attribute of the HTML tag does not update when the user changes the language with the language picker, which undermines accessibility.


## Proposal

- [x] update HTML tag when i18next client detects a language change at user input
- [x] include in HTML tag a default value for lang attribute according to browser language (amid supported languages)
