### PR TITLE
📝(readme) update admin credentials in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You first need to create a superuser account:
 $ make superuser
 ```
 
-You can then login with credentials `admin@example` / `admin`.
+You can then login with sub `admin` and password `admin`.
 
 ### Run frontend
 


### PR DESCRIPTION
## Purpose

README was not correctly updated after last major modif to the admin auth, resulting in confusion for users trying to log-in with email instead of sub. 

fixes #307 
