### PR TITLE
🚚(api) move swagger under /api/

### DIFF
--- a/src/backend/core/tests/swagger/test_openapi_schema.py
+++ b/src/backend/core/tests/swagger/test_openapi_schema.py
@@ -33,7 +33,7 @@ def test_openapi_client_schema():
     )
     assert output.getvalue() == ""
 
-    response = Client().get("/v1.0/swagger.json")
+    response = Client().get("/api/v1.0/swagger.json")
 
     assert response.status_code == 200
     with open(

--- a/src/backend/people/urls.py
+++ b/src/backend/people/urls.py
@@ -33,7 +33,7 @@ if settings.DEBUG:
 if settings.USE_SWAGGER or settings.DEBUG:
     urlpatterns += [
         path(
-            f"{API_VERSION}/swagger.json",
+            f"api/{API_VERSION}/swagger.json",
             SpectacularJSONAPIView.as_view(
                 api_version=API_VERSION,
                 urlconf="people.api_urls",
@@ -41,12 +41,12 @@ if settings.USE_SWAGGER or settings.DEBUG:
             name="client-api-schema",
         ),
         path(
-            f"{API_VERSION}/swagger/",
+            f"api/{API_VERSION}/swagger/",
             SpectacularSwaggerView.as_view(url_name="client-api-schema"),
             name="swagger-ui-schema",
         ),
         re_path(
-            f"{API_VERSION}/redoc/",
+            f"api/{API_VERSION}/redoc/",
             SpectacularRedocView.as_view(url_name="client-api-schema"),
             name="redoc-schema",
         ),


### PR DESCRIPTION
## Purpose

Swagger was under /v1.0/swagger. I just wanna move it under /api/ where the rest of the API is. 

