### PR TITLE
🩺(coverage) add config and make rule to compute coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ src/frontend/tsclient
 
 # Test & lint
 .coverage
+coverage.json
 .pylint.d
 .pytest_cache
 db.sqlite3

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ test-back-parallel: ## run all back-end tests in parallel
 	bin/pytest -n auto $${args:-${1}}
 .PHONY: test-back-parallel
 
+test-coverage: ## compute, display and save test coverage
+	bin/pytest --cov=. --cov-report json .
+.PHONY: test-coverage
+
 makemigrations:  ## run django makemigrations for the people project.
 	@echo "$(BOLD)Running makemigrations$(RESET)"
 	@$(COMPOSE) up -d postgresql

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -137,3 +137,22 @@ python_files = [
     "test_*.py",
     "tests.py",
 ]
+
+[tool.coverage.run]
+branch = true
+omit = [
+    "*/admin.py", 
+    "*/migrations/*", 
+    "*/tests/*",
+    "*/urls.py",
+    "manage.py",
+    "celery_app.py",
+    "wsgi.py",
+    ]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+
+[tool.coverage.json]
+pretty_print = true

--- a/src/backend/setup.py
+++ b/src/backend/setup.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""Setup file for the people module. All configuration stands in the setup.cfg file."""
-# coding: utf-8
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
## Purpose

Compute test coverage to make sure we test every line, especially upon adding a new feature.

## Proposal

- [x] Configure pytest-cov settings in pyproject.toml
- [x] make rule in Makefile


## Improvements
- Should we add a run of coverage in the CI ? We could set a branch rule stating, say, that a branch cannot be merged if it makes coverage go under, say, 90% on main. WDYT ?