### PR TITLE
Suppression temporaire de la méthode DELETE sur le mail domain dans l'api

### DIFF
--- a/src/backend/mailbox_manager/api/viewsets.py
+++ b/src/backend/mailbox_manager/api/viewsets.py
@@ -14,7 +14,6 @@ class MailDomainViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
-    mixins.DestroyModelMixin,
     viewsets.GenericViewSet,
 ):
     """
@@ -29,9 +28,6 @@ class MailDomainViewSet(
     POST /api/<version>/mail-domains/ with expected data:
         - name: str
         Return newly created domain
-
-    DELETE /api/<version>/mail-domains/<domain-slug>/
-        Delete targeted team access
     """
 
     permission_classes = [permissions.AccessPermission]

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 
 from core import factories as core_factories
 
-from mailbox_manager import factories, models
+from mailbox_manager import enums, factories, models
 
 pytestmark = pytest.mark.django_db
 
@@ -67,6 +67,8 @@ def test_api_mail_domains__create_authenticated():
     )
 
     assert response.status_code == status.HTTP_201_CREATED
+    # a new domain pending is created and the authenticated user is the owner
     domain = models.MailDomain.objects.get()
+    assert domain.status == enums.MailDomainStatusChoices.PENDING
     assert domain.name == "mydomain.com"
     assert domain.accesses.filter(role="owner", user=user).exists()

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_delete.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_delete.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_api_mail_domains__delete_anonymous():
-    """Anonymous users should not be allowed to destroy a team."""
+    """Anonymous users should not be allowed to destroy a domain."""
     domain = factories.MailDomainFactory()
 
     response = APIClient().delete(


### PR DESCRIPTION
Pour l'instant on ne permet pas de supprimer un domaine. 
On implémentera 2 fonctionnements distincts 
- un admin ou un owner pourra supprimer un domaine si celui ci est en pending encore
- si le domain est en état actif alors le propriétaire pourra seulement le désactiver.