### PR TITLE
Mailbox creation and view improvements

### DIFF
--- a/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
@@ -91,6 +91,7 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
       <TopBanner
         name={mailDomain.name}
         setIsFormVisible={setIsCreateMailboxFormVisible}
+        abilities={mailDomain.abilities}
       />
       <Card
         $padding={{ bottom: 'small' }}
@@ -127,9 +128,11 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
 const TopBanner = ({
   name,
   setIsFormVisible,
+  abilities,
 }: {
   name: string;
   setIsFormVisible: (value: boolean) => void;
+  abilities: MailDomain['abilities'];
 }) => {
   const { t } = useTranslation();
 
@@ -147,12 +150,14 @@ const TopBanner = ({
         </Text>
       </Box>
       <Box $margin={{ all: 'big', bottom: 'small' }} $align="flex-end">
-        <Button
-          aria-label={t(`Create a mailbox in {{name}} domain`, { name })}
-          onClick={() => setIsFormVisible(true)}
-        >
-          {t('Create a mailbox')}
-        </Button>
+        {abilities.post ? (
+          <Button
+            aria-label={t(`Create a mailbox in {{name}} domain`, { name })}
+            onClick={() => setIsFormVisible(true)}
+          >
+            {t('Create a mailbox')}
+          </Button>
+        ) : null}
       </Box>
     </>
   );

--- a/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/components/MailDomainsContent.tsx
@@ -1,3 +1,5 @@
+import { UUID } from 'crypto';
+
 import {
   Button,
   DataGrid,
@@ -17,7 +19,11 @@ import { MailDomain, MailDomainMailbox } from '../types';
 
 import { CreateMailboxForm } from './forms/CreateMailboxForm';
 
-export type ViewMailbox = { email: string; id: string };
+export type ViewMailbox = {
+  name: string;
+  email: string;
+  id: UUID;
+};
 
 // FIXME : ask Cunningham to export this type
 type SortModelItem = {
@@ -69,6 +75,7 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
     mailDomain && data?.results?.length
       ? data.results.map((mailbox: MailDomainMailbox) => ({
           email: `${mailbox.local_part}@${mailDomain.name}`,
+          name: `${mailbox.first_name} ${mailbox.last_name}`,
           id: mailbox.id,
         }))
       : [];
@@ -76,6 +83,7 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
   useEffect(() => {
     setPagesCount(data?.count ? Math.ceil(data.count / pageSize) : 0);
   }, [data?.count, pageSize, setPagesCount]);
+
   return isLoading ? (
     <Box $align="center" $justify="center" $height="100%">
       <Loader />
@@ -88,19 +96,35 @@ export function MailDomainsContent({ mailDomain }: { mailDomain: MailDomain }) {
           closeModal={() => setIsCreateMailboxFormVisible(false)}
         />
       ) : null}
+
       <TopBanner
         name={mailDomain.name}
         setIsFormVisible={setIsCreateMailboxFormVisible}
-        abilities={mailDomain.abilities}
+        abilities={mailDomain?.abilities}
       />
+
       <Card
         $padding={{ bottom: 'small' }}
         $margin={{ all: 'big', top: 'none' }}
         $overflow="auto"
       >
         {error && <TextErrors causes={error.cause} />}
+
         <DataGrid
           columns={[
+            {
+              field: 'name',
+              headerName: t('Names'),
+              renderCell: ({ row }) => (
+                <Text
+                  $weight="bold"
+                  $theme="primary"
+                  $css="text-transform: capitalize;"
+                >
+                  {row.name}
+                </Text>
+              ),
+            },
             {
               field: 'email',
               headerName: t('Emails'),

--- a/src/frontend/apps/desk/src/features/mail-domains/types.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/types.tsx
@@ -19,5 +19,7 @@ export interface MailDomain {
 export interface MailDomainMailbox {
   id: UUID;
   local_part: string;
+  first_name: string;
+  last_name: string;
   secondary_email: string;
 }

--- a/src/frontend/apps/desk/src/features/mail-domains/types.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/types.tsx
@@ -6,6 +6,14 @@ export interface MailDomain {
   created_at: string;
   updated_at: string;
   slug: string;
+  abilities: {
+    get: boolean;
+    patch: boolean;
+    put: boolean;
+    post: boolean;
+    delete: boolean;
+    manage_accesses: boolean;
+  };
 }
 
 export interface MailDomainMailbox {

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -12,6 +12,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'domainfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'mails.fr',
@@ -19,6 +27,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'mailsfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'versailles.net',
@@ -26,6 +42,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'versaillesnet',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'paris.fr',
@@ -33,6 +57,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'parisfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
 ];
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -163,11 +163,15 @@ test.describe('Mail domain', () => {
       domainFr: {
         page1: Array.from({ length: 20 }, (_, i) => ({
           id: `456ac6ca-0402-4615-8005-69bc1efde${i}f`,
+          first_name: 'john',
+          last_name: 'doe',
           local_part: `local_part-${i}`,
           secondary_email: `secondary_email-${i}`,
         })),
         page2: Array.from({ length: 2 }, (_, i) => ({
           id: `456ac6ca-0402-4615-8005-69bc1efde${i}d`,
+          first_name: 'john',
+          last_name: 'doe',
           local_part: `local_part-${i}`,
           secondary_email: `secondary_email-${i}`,
         })),
@@ -236,6 +240,10 @@ test.describe('Mail domain', () => {
     ).toBeVisible();
 
     await expect(
+      page.getByRole('button', { name: /Names/ }).first(),
+    ).toBeVisible();
+
+    await expect(
       page.getByRole('button', { name: /Emails/ }).first(),
     ).toBeVisible();
 
@@ -248,6 +256,12 @@ test.describe('Mail domain', () => {
         ).toBeVisible(),
       ),
     );
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+
+    const tdNames = await table.getByText('John Doe').all();
+    expect(tdNames.length).toEqual(20);
 
     await expect(
       page.locator('.c__pagination__list').getByRole('button', { name: '1' }),

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domains.spec.ts
@@ -11,6 +11,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'domainfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'mails.fr',
@@ -18,6 +26,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'mailsfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'versailles.net',
@@ -25,6 +41,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'versaillesnet',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
   {
     name: 'paris.fr',
@@ -32,6 +56,14 @@ const mailDomainsFixtures: MailDomain[] = [
     created_at: currentDateIso,
     updated_at: currentDateIso,
     slug: 'parisfr',
+    abilities: {
+      get: true,
+      patch: true,
+      put: true,
+      post: true,
+      delete: true,
+      manage_accesses: true,
+    },
   },
 ];
 


### PR DESCRIPTION
## Purpose
- A user should not be allowed to create a mailbox when the ability is not granted.
The commit b637774 introduced rights restrictions on mailbox management in the backend. Now, a user not possessing the `post` ability on a mail domain can not create a mailbox.

- Each mailbox row in the tab should display the full name of its owner.
The commit c00c59b introduced the first and last names in mailbox data. We can now display them.

## Proposal
On /mail-domains/\<mail-domain-slug\> view:
- Hide the mailbox creation button if the post ability is falsy
- Show the full name of a mailbox owner for each row on the left column of the table

closes #324, closes #330, closes #294.

