### PR TITLE
Corrige un test en échec intermittent

### DIFF
--- a/src/backend/core/tests/team_accesses/test_api_team_accesses_list.py
+++ b/src/backend/core/tests/team_accesses/test_api_team_accesses_list.py
@@ -223,7 +223,7 @@ def test_api_team_accesses__list_find_members_by_email():
     Authenticated users should be able to search users access with a case-insensitive and
     partial query on the email.
     """
-    user = factories.UserFactory(name=None)
+    user = factories.UserFactory(name=None, email="alicia@example.com")
 
     # set all names to None to match only on emails
     colleague1 = factories.UserFactory(name=None, email="prudence_crandall@edu.us")


### PR DESCRIPTION
Dans `test_api_team_accesses__list_find_members_by_email`.

Avec cette modification, on supprime les échecs aléatoires du test lorsque l'adresse attribuée à l'utilisateur source par FactoryBoy est considérée comme suffisamment similaire à BRUNE lors de la recherche par trigramme.

Fixes #326 (en partie: créer des issues pour les autres tests présentant des échecs aléatoires).

C'est un quick fix: pour une solution long terme il serait peut-être utile de revisiter ou alternativement de mieux documenter le choix de la recherche par trigramme pour le viewset TeamAccesses.