### PR TITLE
[ADMIN DJANGO] Amélioration affichage et gestion des users

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -42,7 +42,7 @@ class UserAdmin(auth_admin.UserAdmin):
                 )
             },
         ),
-        (_("Personal info"), {"fields": ("email", "language", "timezone")}),
+        (_("Personal info"), {"fields": ("name", "email", "language", "timezone")}),
         (
             _("Permissions"),
             {
@@ -69,8 +69,7 @@ class UserAdmin(auth_admin.UserAdmin):
     )
     inlines = (TeamAccessInline, MailDomainAccessInline)
     list_display = (
-        "sub",
-        "email",
+        "get_user",
         "created_at",
         "updated_at",
         "is_active",
@@ -81,13 +80,21 @@ class UserAdmin(auth_admin.UserAdmin):
     list_filter = ("is_staff", "is_superuser", "is_device", "is_active")
     ordering = ("is_active", "-is_superuser", "-is_staff", "-is_device", "-updated_at")
     readonly_fields = ["id", "created_at", "updated_at"]
-    search_fields = ("id", "email", "sub")
+    search_fields = ("id", "email", "sub", "name")
 
     def get_readonly_fields(self, request, obj=None):
         """The sub should only be editable for a create, not for updates."""
         if obj:
             return self.readonly_fields + ["sub"]
         return self.readonly_fields
+
+    def get_user(self, obj):
+        """Provide a nice display for user"""
+        return (
+            obj.name if obj.name else (obj.email if obj.email else f"[sub] {obj.sub}")
+        )
+
+    get_user.short_description = _("User")
 
 
 @admin.register(models.Team)

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
 
+from mailbox_manager.admin import MailDomainAccessInline
+
 from . import models
 
 
@@ -65,7 +67,7 @@ class UserAdmin(auth_admin.UserAdmin):
             },
         ),
     )
-    inlines = (TeamAccessInline,)
+    inlines = (TeamAccessInline, MailDomainAccessInline)
     list_display = (
         "sub",
         "email",

--- a/src/backend/mailbox_manager/admin.py
+++ b/src/backend/mailbox_manager/admin.py
@@ -34,6 +34,15 @@ class MailDomainAccessAdmin(admin.ModelAdmin):
     )
 
 
+class MailDomainAccessInline(admin.TabularInline):
+    """Inline admin class for mail domain accesses."""
+
+    extra = 0
+    autocomplete_fields = ["user", "domain"]
+    model = models.MailDomainAccess
+    readonly_fields = ("created_at", "updated_at")
+
+
 @admin.register(models.Mailbox)
 class MailboxAdmin(admin.ModelAdmin):
     """Admin for mailbox model."""


### PR DESCRIPTION
1/ Modification de l'affichage des users dans la vue liste. 
On affiche l'email si il existe à la place du sub.

![Capture d’écran 2024-08-27 à 10 18 25](https://github.com/user-attachments/assets/e5830403-4ab6-475e-8b94-e158c28503d1)

2/ Ajout d'un inline pour gérer les rôles les noms de domaine sur le formulaire de création et édition d'un user
![Capture d’écran 2024-08-27 à 10 19 54](https://github.com/user-attachments/assets/3302d7d4-b80d-41b4-89a2-0d45ac08b6b4)
