### PR TITLE
🍱(dimail) embark dimail-api as container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
-✨(domains) add endpoint API to list all accesses created for a domain
 
+### Added
+
+- ✨(domains) add endpoint to list and retrieve domain accesses @sdemagny #404
+- 🍱(dev) embark dimail-api as container by @mjeammet #366
 
 ## [1.1.0] - 2024-09-10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,3 +166,11 @@ services:
       - "8080:8080"
     depends_on:
       - kc_postgresql
+
+  dimail: 
+    image: registry.mim-libre.fr/dimail/dimail-api:latest
+    environment:
+      DIMAIL_MODE: FAKE
+      DIMAIL_JWT_SECRET: fake_jwt_secret
+    ports:
+      - "8001:8000"

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -232,7 +232,8 @@ def test_api_mailboxes__create_administrator_missing_fields():
     assert response.json() == {"secondary_email": ["This field is required."]}
 
 
-### SYNC TO PROVISIONING API
+### REACTING TO DIMAIL-API
+### We mock dimail's responses to avoid testing dimail's container too
 
 
 def test_api_mailboxes__unrelated_user_provisioning_api_not_called():
@@ -297,7 +298,7 @@ def test_api_mailboxes__domain_owner_or_admin_successful_creation_and_provisioni
     """
     Domain owner/admin should be able to create mailboxes.
     Provisioning API should be called when owner/admin makes a call.
-    Expected response contains new email and password.
+    Succesfull 201 response from dimail should trigger mailbox creation on our side.
     """
     # creating all needed objects
     access = factories.MailDomainAccessFactory(role=role)
@@ -367,7 +368,7 @@ def test_api_mailboxes__domain_owner_or_admin_successful_creation_and_provisioni
 def test_api_mailboxes__dimail_token_permission_denied():
     """
     API should raise a clear "permission denied" error
-    when receiving a 403_forbidden from dimail.
+    when receiving a permission denied from dimail upon requesting token.
     """
     # creating all needed objects
     access = factories.MailDomainAccessFactory(role=enums.MailDomainRoleChoices.OWNER)
@@ -448,7 +449,7 @@ def test_api_mailboxes__user_unrelated_to_domain():
 
 def test_api_mailboxes__handling_dimail_unexpected_error():
     """
-    API should raise a clear error when dimail gives an unexpected response.
+    API should raise a clear error when dimail returns an unexpected response.
     """
     # creating all needed objects
     access = factories.MailDomainAccessFactory(role=enums.MailDomainRoleChoices.OWNER)

--- a/src/backend/mailbox_manager/tests/test_models_mailboxes.py
+++ b/src/backend/mailbox_manager/tests/test_models_mailboxes.py
@@ -141,7 +141,8 @@ def test_models_mailboxes__cannot_be_created_for_pending_maildomain():
         factories.MailboxFactory(domain=factories.MailDomainFactory())
 
 
-### SYNC TO DIMAIL-API
+### REACTING TO DIMAIL-API
+### We mock dimail's responses to avoid testing dimail's container too
 
 
 @override_settings(MAIL_PROVISIONING_API_CREDENTIALS=None)
@@ -232,7 +233,6 @@ def test_models_mailboxes__create_mailbox_success(mock_info, mock_error):
 
         # Check headers
         headers = rsps.calls[1].request.headers
-        # assert "Authorization" not in headers
         assert headers["Content-Type"] == "application/json"
 
         # Payload sent to mailbox provider

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -417,7 +417,7 @@ class Base(Configuration):
 
     # MAILBOX-PROVISIONING API
     MAIL_PROVISIONING_API_URL = values.Value(
-        default="https://api.dev.ox.numerique.gouv.fr",
+        default="http://host.docker.internal:8001",
         environ_name="MAIL_PROVISIONING_API_URL",
         environ_prefix=None,
     )

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -50,7 +50,7 @@ backend:
     POSTGRES_USER: dinum
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
-    MAIL_PROVISIONING_API_URL: "http://host.docker.internal:8000"
+    MAIL_PROVISIONING_API_URL: "http://host.docker.internal:8001"
     MAIL_PROVISIONING_API_CREDENTIALS:
       secretKeyRef:
         name: backend


### PR DESCRIPTION
## Purpose

This PR is made to embark [dimail-api](4a135fb3382fcf042c2ec6700c1d4090a10c2cc9)'s container, automatically fetched from their repository, up-to-date with their `main` branch, and running in "FAKE" mode.  By using the real code, we ensure we are iso with their latest development, which will ease up interop development.

⚠️  The container we're using is currently built on our friends' `main` branch. We might want to rely on a more stable branch/keyword later.

⚠️ Our intention has shifted from earlier development. We first wanted to remove all mocks to use the real container directly in dev and tests. but then realized
-  this means OUR tests are broken and **we can't merge** if dimail's tests break / change their responses
- we're rather see dimail as an external dependency. We don't need to test dimail's code when it's already tested on their part 

## Proposal
- [x] add dimail container to docker configuration

## For next PR
- write make command to create first admin user in dimail container (next
- document dimail use


