### PR TITLE
🐛(dimail) improve handling of dimail errors on failed mailbox creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(dimail) improve handling of dimail errors on failed mailbox creation #377 
+
 ## [1.0.2] - 2024-08-30
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgresql:
     image: postgres:16

--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -146,11 +146,11 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='contact',
-            constraint=models.CheckConstraint(check=models.Q(('base__isnull', False), ('owner__isnull', True), _negated=True), name='base_owner_constraint', violation_error_message='A contact overriding a base contact must be owned.'),
+            constraint=models.CheckConstraint(condition=models.Q(('base__isnull', False), ('owner__isnull', True), _negated=True), name='base_owner_constraint', violation_error_message='A contact overriding a base contact must be owned.'),
         ),
         migrations.AddConstraint(
             model_name='contact',
-            constraint=models.CheckConstraint(check=models.Q(('base', models.F('id')), _negated=True), name='base_not_self', violation_error_message='A contact cannot be based on itself.'),
+            constraint=models.CheckConstraint(condition=models.Q(('base', models.F('id')), _negated=True), name='base_not_self', violation_error_message='A contact cannot be based on itself.'),
         ),
         migrations.AlterUniqueTogether(
             name='contact',

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -124,12 +124,12 @@ class Contact(BaseModel):
         unique_together = ("owner", "base")
         constraints = [
             models.CheckConstraint(
-                check=~models.Q(base__isnull=False, owner__isnull=True),
+                condition=~models.Q(base__isnull=False, owner__isnull=True),
                 name="base_owner_constraint",
                 violation_error_message="A contact overriding a base contact must be owned.",
             ),
             models.CheckConstraint(
-                check=~models.Q(base=models.F("id")),
+                condition=~models.Q(base=models.F("id")),
                 name="base_not_self",
                 violation_error_message="A contact cannot be based on itself.",
             ),

--- a/src/backend/mailbox_manager/tests/test_models_mailboxes.py
+++ b/src/backend/mailbox_manager/tests/test_models_mailboxes.py
@@ -168,17 +168,10 @@ def test_models_mailboxes__wrong_secret():
             status=status.HTTP_403_FORBIDDEN,
             content_type="application/json",
         )
-        rsps.add(
-            rsps.POST,
-            re.compile(rf".*/domains/{domain.name}/mailboxes/"),
-            body='{"detail": "Permission denied"}',
-            status=status.HTTP_403_FORBIDDEN,
-            content_type="application/json",
-        )
 
         with pytest.raises(
             exceptions.PermissionDenied,
-            match=f"Please check secret of the mail domain {domain.name}",
+            match=f"Token denied - Wrong secret on mail domain {domain.name}",
         ):
             mailbox = factories.MailboxFactory(use_mock=False, domain=domain)
             # Payload sent to mailbox provider


### PR DESCRIPTION
## Purpose

dimail is called twice when creating a mailbox (once for the token,
and once for the post on mailbox endpoint). we want to clarify
the status_codes and messages of each error to inform user and ease debug

## Implementation 

- [x] catch 403 from token
- [x] catch 403 from /mailboxes/new-address/
- [x] catch all other unexpected errors
- [x] 3 related tests
