### PR TITLE
📈(monitoring) configure sentry monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 📈(monitoring) configure sentry monitoring #378
+
 ### Fixed
 
 - 🐛(dimail) improve handling of dimail errors on failed mailbox creation #377 

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -473,6 +473,7 @@ class Base(Configuration):
                 environment=cls.__name__.lower(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
+                traces_sample_rate=1.0,
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")
@@ -654,6 +655,10 @@ class Production(Base):
             },
         },
     }
+    SENTRY_DSN = values.Value(
+        "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171",
+        environ_name="SENTRY_DSN",
+    )
 
 
 class Feature(Production):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "PyJWT==2.9.0",
     "joserfc==1.0.0",
     "requests==2.32.3",
-    "sentry-sdk==2.13.0",
+    "sentry-sdk[django]==2.13.0",
     "url-normalize==1.4.3",
     "whitenoise==6.7.0",
     "mozilla-django-oidc==4.0.1",

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -51,6 +51,7 @@ backend:
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
     MAIL_PROVISIONING_API_URL: "http://host.docker.internal:8000"
+    SENTRY_DSN: "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171"
   command:
     - "gunicorn"
     - "-c"

--- a/src/helm/env.d/preprod/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.desk.yaml.gotmpl
@@ -86,6 +86,7 @@ backend:
         key: url
     MAIL_PROVISIONING_API_URL: "https://api.dev.ox.numerique.gouv.fr"
     FEATURE_TEAMS: False
+    SENTRY_DSN: "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171"
 
   createsuperuser:
     command:

--- a/src/helm/env.d/production/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/production/values.desk.yaml.gotmpl
@@ -86,6 +86,7 @@ backend:
         key: url
     MAIL_PROVISIONING_API_URL: "https://api.dev.ox.numerique.gouv.fr"
     FEATURE_TEAMS: False
+    SENTRY_DSN: "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171"
 
   createsuperuser:
     command:

--- a/src/helm/env.d/staging/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.desk.yaml.gotmpl
@@ -99,7 +99,7 @@ backend:
         name: redis.redis.libre.sh
         key: url
     MAIL_PROVISIONING_API_URL: "https://api.dev.ox.numerique.gouv.fr"
-
+    SENTRY_DSN: "https://b72746c73d669421e7a8ccd3fab0fad2@sentry.incubateur.net/171"
 
   createsuperuser:
     command:


### PR DESCRIPTION
## Purpose

Configure sentry dsn to monitor errors in sentry. 

## Proposal

In Joanie, Sentry DSN is set up in post_setup script. Here, I'll simply put it in settings for now, monitoring all environments to catch all potential errors. I'll remove environment later if we decide we don't need to track certain environments.

- [] item 1...
- [] item 2...
