### PR TITLE
👷(deployment) restrict build-and-push github actions to merge

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -8,9 +8,6 @@ on:
       - 'main'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'main'
 
 env:
   DOCKER_USER: 1001:127


### PR DESCRIPTION
## Purpose

The CI builds and pushes back-end and front-end images to DckerHub every time we push to the repo, including on branches.
I want to relax the CI a little, restricting images builds and pushes to what is necessary (merges on main only, from what I know)

## Proposal

Description...

- [x] restrict to merges, see [this GitHub doc on events triggering workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges) 

Last we spoke, Antoine sounded surprised that images would build outside of tagging but, from what I understood, staging might still need a docker images for kubernetes deployement. But build and push after merging on main might suffice. 

To be discussed.
