### PR TITLE
chore: reduce sentry tracesSampleRate

### DIFF
--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -478,7 +478,7 @@ class Base(Configuration):
                 environment=cls.__name__.lower(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
-                traces_sample_rate=1.0,
+                traces_sample_rate=0.1,
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")


### PR DESCRIPTION
Reduce sentry `tracesSampleRate` as it produces ~100k events/day

<img width="882" alt="Capture d’écran 2024-09-17 à 13 52 55" src="https://github.com/user-attachments/assets/28303c51-3913-47a2-8ba6-d43b9f8cc395">
