### PR TITLE
♻️(serializers) move business logic to serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to
 
 ### Added
 
-- ✨(domains) add endpoint to list and retrieve domain accesses @sdemagny #404
-- 🍱(dev) embark dimail-api as container by @mjeammet #366
+- ✨(domains) add endpoint to list and retrieve domain accesses #404
+- 🍱(dev) embark dimail-api as container #366
+
+
+### Changed
+
+- ♻️(serializers) move business logic to serializers #414 
 
 ## [1.1.0] - 2024-09-10
 

--- a/src/backend/mailbox_manager/api/serializers.py
+++ b/src/backend/mailbox_manager/api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from core.api.serializers import UserSerializer
 
 from mailbox_manager import enums, models
+from mailbox_manager.utils.dimail import DimailAPIClient
 
 
 class MailboxSerializer(serializers.ModelSerializer):
@@ -15,6 +16,14 @@ class MailboxSerializer(serializers.ModelSerializer):
         fields = ["id", "first_name", "last_name", "local_part", "secondary_email"]
         # everything is actually read-only as we do not allow update for now
         read_only_fields = ["id"]
+
+    def create(self, validated_data):
+        """
+        Override create function to fire a request on mailbox creation.
+        """
+        client = DimailAPIClient()
+        client.send_mailbox_request(validated_data)
+        return models.Mailbox.objects.create(**validated_data)
 
 
 class MailDomainSerializer(serializers.ModelSerializer):

--- a/src/backend/mailbox_manager/models.py
+++ b/src/backend/mailbox_manager/models.py
@@ -4,14 +4,13 @@ Declare and configure the models for the People additional application : mailbox
 
 from django.conf import settings
 from django.core import exceptions, validators
-from django.db import models, transaction
+from django.db import models
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
 from core.models import BaseModel
 
 from mailbox_manager.enums import MailDomainRoleChoices, MailDomainStatusChoices
-from mailbox_manager.utils.dimail import DimailAPIClient
 
 
 class MailDomain(BaseModel):
@@ -155,16 +154,12 @@ class Mailbox(BaseModel):
 
     def save(self, *args, **kwargs):
         """
-        Override save function to fire a request on mailbox creation.
         Modification is forbidden for now.
         """
         self.full_clean()
 
         if self._state.adding:
-            with transaction.atomic():
-                client = DimailAPIClient()
-                client.send_mailbox_request(self)
-                return super().save(*args, **kwargs)
+            return super().save(*args, **kwargs)
 
         # Update is not implemented for now
         raise NotImplementedError()

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -64,15 +64,15 @@ class DimailAPIClient:
         """Send a CREATE mailbox request to mail provisioning API."""
 
         payload = {
-            "givenName": mailbox.first_name,
-            "surName": mailbox.last_name,
-            "displayName": f"{mailbox.first_name} {mailbox.last_name}",
+            "givenName": mailbox["first_name"],
+            "surName": mailbox["last_name"],
+            "displayName": f"{mailbox['first_name']} {mailbox['last_name']}",
         }
         headers = self.get_headers()
 
         try:
             response = session.post(
-                f"{self.API_URL}/domains/{mailbox.domain}/mailboxes/{mailbox.local_part}/",
+                f"{self.API_URL}/domains/{mailbox['domain']}/mailboxes/{mailbox['local_part']}/",
                 json=payload,
                 headers=headers,
                 verify=True,
@@ -93,7 +93,7 @@ class DimailAPIClient:
             # In the meantime, we log mailbox info (including password !)
             logger.info(
                 "Mailbox successfully created on domain %s",
-                mailbox.domain.name,
+                str(mailbox["domain"]),
                 extra=extra,
             )
             return response


### PR DESCRIPTION
## Purpose

While working on the feature allowing to request a token for another dimail user, I realized business logic probably didn't belong to where we had put it (the model's save method). 

The purpose of this PR is to suggest a refacto of these elements.

## Proposal

Our resulting discussions aligned with best practices : we'll move all business logic from model to serializer. 
all API calls (direct and from front) will keep on triggering
expected 3rd party calls while admin actions will uniquely trigger
modifications in our database.
