### PR TITLE
✨(dimail) allow la regie to request a token for another user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 
 - ✨(domains) add endpoint to list and retrieve domain accesses #404
 - 🍱(dev) embark dimail-api as container #366
-
+- ✨(dimail) allow la regie to request a token for another user #416 
 
 ### Changed
 

--- a/src/backend/mailbox_manager/api/serializers.py
+++ b/src/backend/mailbox_manager/api/serializers.py
@@ -22,7 +22,7 @@ class MailboxSerializer(serializers.ModelSerializer):
         Override create function to fire a request on mailbox creation.
         """
         client = DimailAPIClient()
-        client.send_mailbox_request(validated_data)
+        client.send_mailbox_request(validated_data, self.context["request"].user.sub)
         return models.Mailbox.objects.create(**validated_data)
 
 

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -496,7 +496,8 @@ def test_api_mailboxes__handling_dimail_unexpected_error():
 @mock.patch.object(Logger, "info")
 def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
     """
-    Upon requesting mailbox creation, things are correctly logged
+    Upon requesting mailbox creation, la régie should impersonate
+    querying user in dimail and log things correctly.
     """
     access = factories.MailDomainAccessFactory(role=enums.MailDomainRoleChoices.OWNER)
 
@@ -536,6 +537,9 @@ def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
         )
         assert response.status_code == status.HTTP_201_CREATED
 
+        # user sub is sent to payload as a parameter
+        assert rsps.calls[0].request.params == {"username": access.user.sub}
+
     # Logger
     assert not mock_error.called
     assert mock_info.call_count == 3
@@ -543,6 +547,7 @@ def test_api_mailboxes__send_correct_logger_infos(mock_info, mock_error):
         "Token succesfully granted by mail-provisioning API.",
     )
     assert mock_info.call_args_list[1][0] == (
-        "Mailbox successfully created on domain %s",
-        access.domain.name,
+        "Mailbox successfully created on domain %s by user %s",
+        str(access.domain),
+        access.user.sub,
     )


### PR DESCRIPTION
## Purpose

Allow la regie to request a token for another dimail user, to better track who created/modified which resource.

## Proposal

Description...

- [x] send context request user sub to mailbox request method
- [x] change logs sent to logger.info upon mailbox creation
