### PR TITLE
🔧(bakend) use new scaleway email gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🔧(mail) use new scaleway email gateway #435 
+
+
 ## [1.2.0] - 2024-09-30
 
 

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -265,10 +265,12 @@ class Base(Configuration):
     # Mail
     EMAIL_BACKEND = values.Value("django.core.mail.backends.smtp.EmailBackend")
     EMAIL_HOST = values.Value(None)
+    EMAIL_HOST_USER = values.Value(None)
+    EMAIL_HOST_PASSWORD = values.Value(None)
     EMAIL_PORT = values.PositiveIntegerValue(None)
+    EMAIL_USE_TLS = values.BooleanValue(False)
     EMAIL_USE_SSL = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@example.com")
-
     AUTH_USER_MODEL = "core.User"
     INVITATION_VALIDITY_DURATION = 604800  # 7 days, in seconds
 

--- a/src/helm/desk/templates/secrets.yaml
+++ b/src/helm/desk/templates/secrets.yaml
@@ -22,3 +22,9 @@ stringData:
 {{- if .Values.mail_provisioning_api_credentials }}
   MAIL_PROVISIONING_API_CREDENTIALS: {{ .Values.mail_provisioning_api_credentials }}
 {{- end }}
+{{- if .Values.djangoEmailHostUser }}
+  DJANGO_EMAIL_HOST_USER: {{ .Values.djangoEmailHostUser }}
+{{- end }}
+{{- if .Values.djangoEmailHostPassword }}
+  DJANGO_EMAIL_HOST_PASSWORD: {{ .Values.djangoEmailHostPassword }}
+{{- end }}

--- a/src/helm/env.d/preprod/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.desk.yaml.gotmpl
@@ -24,9 +24,18 @@ backend:
       secretKeyRef:
         name: backend
         key: DJANGO_SUPERUSER_PASSWORD
-    DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
-    DJANGO_EMAIL_PORT: 465
-    DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_HOST: "smtp.tem.scw.cloud"
+    DJANGO_EMAIL_PORT: 587
+    DJANGO_EMAIL_USE_TLS: True
+    DJANGO_EMAIL_FROM: "noreply@regie.beta.numerique.gouv.fr"
+    DJANGO_EMAIL_HOST_USER:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_USER
+    DJANGO_EMAIL_HOST_PASSWORD:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_PASSWORD
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize

--- a/src/helm/env.d/production/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/production/values.desk.yaml.gotmpl
@@ -24,9 +24,18 @@ backend:
       secretKeyRef:
         name: backend
         key: DJANGO_SUPERUSER_PASSWORD
-    DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
-    DJANGO_EMAIL_PORT: 465
-    DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_HOST: "smtp.tem.scw.cloud"
+    DJANGO_EMAIL_PORT: 587
+    DJANGO_EMAIL_USE_TLS: True
+    DJANGO_EMAIL_FROM: "noreply@regie.beta.numerique.gouv.fr"
+    DJANGO_EMAIL_HOST_USER:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_USER
+    DJANGO_EMAIL_HOST_PASSWORD:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_PASSWORD
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/authorize

--- a/src/helm/env.d/staging/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.desk.yaml.gotmpl
@@ -24,9 +24,18 @@ backend:
       secretKeyRef:
         name: backend
         key: DJANGO_SUPERUSER_PASSWORD
-    DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
-    DJANGO_EMAIL_PORT: 465
-    DJANGO_EMAIL_USE_SSL: True
+    DJANGO_EMAIL_HOST: "smtp.tem.scw.cloud"
+    DJANGO_EMAIL_PORT: 587
+    DJANGO_EMAIL_USE_TLS: True
+    DJANGO_EMAIL_FROM: "noreply@regie.beta.numerique.gouv.fr"
+    DJANGO_EMAIL_HOST_USER:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_USER
+    DJANGO_EMAIL_HOST_PASSWORD:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_EMAIL_HOST_PASSWORD
     DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize


### PR DESCRIPTION
We modify multiples things :
* settings.py in order to manage the new way to send email with the scaleway gateway
* helm template to manage new mandatory secret
* helm configuration for staging/preprod/production
