### PR TITLE
🛂(backend) match email if no existing user matches the sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 
 - ✨(backend) manage roles on domain admin view
 
+### Changed
+
+- 🛂(backend) match email if no existing user matches the sub
+
 ## [1.2.1] - 2024-10-03
 
 ### Fixed

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -413,6 +413,11 @@ class Base(Configuration):
     )
 
     OIDC_TIMEOUT = values.Value(None, environ_name="OIDC_TIMEOUT", environ_prefix=None)
+    OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = values.BooleanValue(
+        default=True,
+        environ_name="OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION",
+        environ_prefix=None,
+    )
 
     # MAILBOX-PROVISIONING API
     WEBMAIL_URL = values.Value(


### PR DESCRIPTION
## Purpose

Some OIDC identity providers may provide a random value in the "sub" field instead of an identifying ID. In this case, it may be a good idea to fallback to matching the user on its email field.

Adaptation of https://github.com/numerique-gouv/impress/pull/303

Needs fixing when brainjuice will be available

## Proposal

Description...

- [] item 1...
- [] item 2...
