### PR TITLE
✨(dimail) send domain creation request to dimail

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -207,6 +207,10 @@ jobs:
         if: always()
         run: docker compose logs > src/frontend/apps/e2e/report/logs.txt
 
+      - name: Save Dimail logs
+        if: always()
+        run: docker compose logs dimail > src/frontend/apps/e2e/report/dimail-logs.txt
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - ⬆️(dependencies) remove unneeded dependencies
 - 🔥(teams) remove pagination of teams listing
 - 🔥(teams) remove search users by trigram
+- 🗃️(teams) remove `slug` field
 
 ### Added
 
@@ -30,10 +31,7 @@ and this project adheres to
 - 🔧(sentry) restore default integrations
 - 🔇(backend) remove Sentry duplicated warning/errors
 - 👷(ci) add sharding e2e tests  #467
-
-### Removed
-
-- 🗃️(teams) remove `slug` field
+- 🐛(dimail) fix unexpected status_code for proper debug #454
 
 ## [1.4.1] - 2024-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(dimail) send domain creation requests to dimail #454
 - ✨(dimail) synchronize mailboxes from dimail to our db #453
 - ✨(ci) add security scan #429
 - ✨(teams) register contacts on admin views

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - ./data/media:/data/media
       - ./data/static:/data/static
     depends_on:
+        - dimail
         - postgresql
         - mailcatcher
         - redis
@@ -168,7 +169,9 @@ services:
       - kc_postgresql
 
   dimail: 
+    entrypoint: /opt/dimail-api/start-dev.sh
     image: registry.mim-libre.fr/dimail/dimail-api:latest
+    pull_policy: always
     environment:
       DIMAIL_MODE: FAKE
       DIMAIL_JWT_SECRET: fake_jwt_secret

--- a/docs/interoperability/dimail.md
+++ b/docs/interoperability/dimail.md
@@ -15,6 +15,8 @@ As dimail's primary goal is to act as an interface between People and OX, its ar
 
 Upon creating a domain on People, the same domain is created on dimail and will undergo a series of checks. When all checks have passed, the domain is considered valid and mailboxes can be created on it. 
 
+Domains in OX have a field called "context". Context is a shared space between domains, allowing users to discover users not only on their domain but on their entire context.
+
 ### Users
 
 The ones issuing requests. Dimail users will reflect domains owners and administrators on People, for logging purposes and to allow direct use of dimail, if desired. User reconciliation is made on user uuid provided by ProConnect.

--- a/src/backend/mailbox_manager/api/serializers.py
+++ b/src/backend/mailbox_manager/api/serializers.py
@@ -77,6 +77,19 @@ class MailDomainSerializer(serializers.ModelSerializer):
             return domain.get_abilities(request.user)
         return {}
 
+    def create(self, validated_data):
+        """
+        Override create function to fire a request to dimail upon domain creation.
+        """
+        # send new domain request to dimail
+        client = DimailAPIClient()
+        client.send_domain_creation_request(
+            validated_data["name"], self.context["request"].user.sub
+        )
+
+        # no exception raised ? Then actually save domain on our database
+        return models.MailDomain.objects.create(**validated_data)
+
 
 class MailDomainAccessSerializer(serializers.ModelSerializer):
     """Serialize mail domain access."""

--- a/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
+++ b/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
@@ -13,7 +13,7 @@ from mailbox_manager.models import MailDomain
 User = get_user_model()
 
 
-DIMAIL_URL = "http://host.docker.internal:8001"
+DIMAIL_URL = "http://dimail:8000"
 admin = {"username": "admin", "password": "admin"}
 regie = {"username": "la_regie", "password": "password"}
 

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
@@ -182,10 +182,9 @@ def test_api_mail_domains__no_creation_when_dimail_duplicate(caplog):
             assert response.json() == {"detail": dimail_error["detail"]}
 
     # check logs
-    assert len(caplog.records) == 2  # 1 + new empty info. To be investigated
     record = caplog.records[0]
     assert record.levelname == "ERROR"
     assert (
         record.message
-        == f"[DIMAIL] {dimail_error['status_code']}: {dimail_error['detail']}"
+        == "[DIMAIL] unexpected error : 409 {'detail': 'Domain already exists'}"
     )

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_create.py
@@ -11,7 +11,6 @@ from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
 
 import pytest
-import requests
 import responses
 from requests.exceptions import HTTPError
 from rest_framework import status
@@ -545,9 +544,11 @@ def test_api_mailboxes__handling_dimail_unexpected_error(caplog):
         assert not models.Mailbox.objects.exists()
 
         # Check error logger was called
-        assert len(caplog.records) == 2  # 1 + new empty info. To be investigated
         assert caplog.records[0].levelname == "ERROR"
-        assert caplog.records[0].message == "[DIMAIL] 500: Internal server error"
+        assert (
+            caplog.records[0].message
+            == "[DIMAIL] unexpected error : 500 {'detail': 'Internal server error'}"
+        )
 
 
 @mock.patch.object(Logger, "error")

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -1,6 +1,7 @@
 """A minimalist client to synchronize with mailbox provisioning API."""
 
 import ast
+import json
 import smtplib
 from email.errors import HeaderParseError, NonASCIILocalPartDefect
 from email.headerregistry import Address
@@ -13,6 +14,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 import requests
+from requests.exceptions import HTTPError
 from rest_framework import status
 from urllib3.util import Retry
 
@@ -157,7 +159,7 @@ class DimailAPIClient:
 
     def pass_dimail_unexpected_response(self, response):
         """Raise error when encountering an unexpected error in dimail."""
-        error_content = response.content.decode("utf-8")
+        error_content = json.loads(response.content.decode(response.encoding).replace("'", '"'))
 
         logger.error(
             "[DIMAIL] unexpected error : %s %s", response.status_code, error_content

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -82,9 +82,10 @@ class DimailAPIClient:
         """Send a domain creation request to dimail API."""
 
         payload = {
-            "domain": domain_name,
-            "context": domain_name,  # for now, we put each domain on its own context
-            "features": ["webmail", "mailboxes"],
+            "name": domain_name,
+            "context_name": domain_name,  # for now, we put each domain on its own context
+            "features": ["webmail", "mailbox"],
+            "delivery": "virtual",
         }
         try:
             response = session.post(
@@ -159,7 +160,10 @@ class DimailAPIClient:
 
     def pass_dimail_unexpected_response(self, response):
         """Raise error when encountering an unexpected error in dimail."""
-        error_content = json.loads(response.content.decode(response.encoding).replace("'", '"'))
+        try:
+            error_content = json.loads(response.content.decode(response.encoding).replace("'", '"'))
+        except:
+            error_content = response.content.decode(response.encoding)
 
         logger.error(
             "[DIMAIL] unexpected error : %s %s", response.status_code, error_content

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -14,7 +14,6 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 import requests
-from requests.exceptions import HTTPError
 from rest_framework import status
 from urllib3.util import Retry
 
@@ -161,8 +160,10 @@ class DimailAPIClient:
     def pass_dimail_unexpected_response(self, response):
         """Raise error when encountering an unexpected error in dimail."""
         try:
-            error_content = json.loads(response.content.decode(response.encoding).replace("'", '"'))
-        except:
+            error_content = json.loads(
+                response.content.decode(response.encoding).replace("'", '"')
+            )
+        except json.decoder.JSONDecodeError:
             error_content = response.content.decode(response.encoding)
 
         logger.error(

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -76,6 +76,40 @@ class DimailAPIClient:
 
         return self.pass_dimail_unexpected_response(response)
 
+    def send_domain_creation_request(self, domain_name, request_user):
+        """Send a domain creation request to dimail API."""
+
+        payload = {
+            "domain": domain_name,
+            "context": domain_name,  # for now, we put each domain on its own context
+            "features": ["webmail", "mailboxes"],
+        }
+        try:
+            response = session.post(
+                f"{self.API_URL}/domains/",
+                json=payload,
+                headers={"Authorization": f"Basic {self.API_CREDENTIALS}"},
+                verify=True,
+                timeout=10,
+            )
+        except requests.exceptions.ConnectionError as error:
+            logger.error(
+                "Connection error while trying to reach %s.",
+                self.API_URL,
+                exc_info=error,
+            )
+            raise error
+
+        if response.status_code == status.HTTP_201_CREATED:
+            logger.info(
+                "Domain %s successfully created on dimail by user %s",
+                domain_name,
+                request_user,
+            )
+            return response
+
+        return self.pass_dimail_unexpected_response(response)
+
     def send_mailbox_request(self, mailbox, user_sub=None):
         """Send a CREATE mailbox request to mail provisioning API."""
 

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -568,6 +568,9 @@ class Development(Base):
         }
     )
 
+    # this is a dev credentials for mail provisioning API
+    MAIL_PROVISIONING_API_CREDENTIALS = "bGFfcmVnaWU6cGFzc3dvcmQ="
+
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
         # pylint: disable=invalid-name

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -432,7 +432,7 @@ class Base(Configuration):
         environ_prefix=None,
     )
     MAIL_PROVISIONING_API_URL = values.Value(
-        default="http://host.docker.internal:8001",
+        default="http://dimail:8000",
         environ_name="MAIL_PROVISIONING_API_URL",
         environ_prefix=None,
     )

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -52,7 +52,7 @@ backend:
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
     WEBMAIL_URL: "https://onestendev.yapasdewebmail.fr"
-    MAIL_PROVISIONING_API_URL: "http://host.docker.internal:8001"
+    MAIL_PROVISIONING_API_URL: "http://dimail:8000"
     MAIL_PROVISIONING_API_CREDENTIALS:
       secretKeyRef:
         name: backend


### PR DESCRIPTION
## Purpose

Send domain creation request to dimail when someone creates a domain in people.


## Proposal

Description...

- [x] write function in dimail client
- [x] write an all-OK test
- [x] check actual dimail response upon sending only the "name" of the domain (and check which features must be enabled for valid domain)
...
