### PR TITLE
🛂(backend) do not duplicate user when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to
 
 - 🛂(backend) match email if no existing user matches the sub
 
+### Fixed
+
+- 🛂(backend) do not duplicate user when disabled
+
 ## [1.2.1] - 2024-10-03
 
 ### Fixed


### PR DESCRIPTION
## Purpose

When a user is disabled and tries to login, we don't want the user to be duplicated, the user should not be able to login.

Fixes https://github.com/numerique-gouv/people/issues/455

## Proposal

- [x] look for existing user with the same sub (or fallback on email) even if disabled
- [x] do not allow login for disabled users
