### PR TITLE
✨(api) add RELEASE version on config endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- ✨(api) add RELEASE version on config endpoint #459
 - 🐛(frontend) fix update accesses form #448
 
 ### Added

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -506,7 +506,7 @@ class ConfigView(views.APIView):
         GET /api/v1.0/config/
             Return a dictionary of public settings.
         """
-        array_settings = ["LANGUAGES", "FEATURES"]
+        array_settings = ["LANGUAGES", "FEATURES", "RELEASE"]
         dict_settings = {}
         for setting in array_settings:
             dict_settings[setting] = getattr(settings, setting)

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -21,6 +21,7 @@ def test_api_config_anonymous():
     assert response.json() == {
         "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"]],
         "FEATURES": {"TEAMS": True},
+        "RELEASE": "NA",
     }
 
 
@@ -36,4 +37,5 @@ def test_api_config_authenticated():
     assert response.json() == {
         "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"]],
         "FEATURES": {"TEAMS": True},
+        "RELEASE": "NA",
     }

--- a/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
@@ -23,6 +23,7 @@ test.describe('Config', () => {
         ['fr-fr', 'French'],
       ],
       FEATURES: { TEAMS: true },
+      RELEASE: 'NA',
     });
   });
 


### PR DESCRIPTION
Add release version deployed to config endpoint
in order to display release info in La Régie footer.

Fixes #459 