### PR TITLE
🐛(sentry) fix duplicated sentry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(sentry) fix duplicated sentry errors #479
 - 🐛(script) improve and fix release script
-
 
 ## [1.3.1] - 2024-10-18
 

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -488,6 +488,7 @@ class Base(Configuration):
                 release=get_release(),
                 integrations=[DjangoIntegration()],
                 traces_sample_rate=0.1,
+                default_integrations=False,
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")


### PR DESCRIPTION
## Purpose

errors were sent to sentry twice, they should now appear only once

https://docs.sentry.io/platforms/python/integrations/django/#issue-reporting
"Logs emitted by any logger will be recorded as breadcrumbs by the Logging integration (this integration is enabled by default)."
https://docs.sentry.io/platforms/python/integrations/default-integrations/
" To disable all system integrations, set default_integrations=False when calling init()."

## Proposal

Description...

- [] item 1...
- [] item 2...
