### PR TITLE
Improve E2E tests: fix stability issues, tighten controls

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -203,6 +203,10 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
+      - name: Save logs
+        if: always()
+        run: docker compose logs > src/frontend/apps/e2e/report/logs.txt
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- 💚(ci) improve E2E tests #492
 - 🔧(sentry) restore default integrations
 - 🔇(backend) remove Sentry duplicated warning/errors
 - 👷(ci) add sharding e2e tests  #467

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -156,8 +156,13 @@ def create_demo(stdout):
         queue.flush()
 
     with Timeit(stdout, "Creating domains"):
+        created = set()
         for _i in range(defaults.NB_OBJECTS["domains"]):
             name = fake.domain_name()
+            if name in created:
+                continue
+            created.add(name)
+
             slug = slugify(name)
 
             queue.push(

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Fail fast */
+  retries: 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -28,7 +28,7 @@ export default defineConfig({
     baseURL: baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
   },
 
   webServer: {

--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Fail fast */
   retries: 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html', { outputFolder: './report' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Purpose

At present E2E tests are more of a burden on the team than they are helping with quality, due to instability which I believe was mainly caused by parallel workers, but these problems were hidden by the two-retries policy.

This PR fixes some of the stability issues but also argues for following the testing philosophy **"fail fast"**.

Rather than "retrying flaky tests" I propose seeing any test failure, even intermittent, as a sign of a potential problem. The right thing to do with a potential problem is not, as it were, to sweep it under the rug, but to fix it for the future.

If a test is truly flaky then it needs to be fixed or removed - E2E tests need to pull their weight, given their cost in terms of longer feedback loops.

## Proposal

This PR
- rolls back the "multiple workers in CI " change made in #31 (which is redundant with sharding anyway)
- disables retries - if tests fail, we want to diagnose and fix the failure
- saves Playwright traces (which were super helpful in diagnosing these problems)
- saves server logs alongside traces for ease of debugging
- adds a QR fix to the occasional failure in "Add dummy data", caused by FactoryGirl sometimes creating duplicate domains

Fixes #409 (hopefully)