### PR TITLE
Use list reporter in addition to html

### DIFF
--- a/src/frontend/apps/e2e/playwright.config.ts
+++ b/src/frontend/apps/e2e/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['html', { outputFolder: './report' }]],
+  reporter: [['html', { outputFolder: './report' }], ['list']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: baseURL,


### PR DESCRIPTION
## Purpose

Tiny PR that was intended to aid in debugging E2E test duration issues, but also has a more tangible benefit of helping identify slow tests.

## Proposal

By default the test runner uses the `null` reporter for outputting to stdio. I suspect that this suppresses output in CI, so that if all tests run successfully, *nothing* gets output at all (until an eventual cancellation for exceeding the time budget). But it's also possible that the runner is somehow getting stuck after emitting a line like `Running 37 tests using 1 worker, shard 1 of 4`.

Using the `list` reporter distinguishes between the two cases. If the job is interrupted, we can know how many tests were run. And as a nice bonus, we get timings for each separate test in the run, which can be useful in fixing slow tests.