### PR TITLE
Fix version data generation and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(debug) fix version data generation and display
 - 🐛(mail) fix display button on outlook
 - 💚(ci) improve E2E tests #492
 - 🔧(sentry) restore default integrations

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -12,3 +12,6 @@ def run_command(cmd, msg=None, shell=False, cwd='.', stdout=None):
     subprocess.check_call(cmd, shell=shell, cwd=cwd, stdout=stdout, stderr=stdout)
     if stdout is not None:
         stdout.flush()
+
+def capture_shell(cmd, msg=None, cwd='.', stdout=None):
+    return subprocess.check_output(cmd, shell=True, cwd=cwd, stderr=stdout)

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -39,7 +39,10 @@ def get_release():
     # CI during the Docker image build
     try:
         with open(os.path.join(BASE_DIR, "version.json"), encoding="utf8") as version:
-            return json.load(version)["version"]
+            verdict = json.load(version)
+            v = verdict["version"]
+            h = verdict["commit"]
+            return f"{v} - {h}"
     except FileNotFoundError:
         return "NA"  # Default: not available
 

--- a/src/frontend/apps/desk/src/features/footer/Footer.tsx
+++ b/src/frontend/apps/desk/src/features/footer/Footer.tsx
@@ -150,7 +150,8 @@ export const Footer = () => {
         >
           {config?.RELEASE && (
             <>
-              {t(`Version: {{release}}`, { release: config?.RELEASE })} •&nbsp;
+              {t(`Version: {{release}}`, { release: config?.RELEASE })}
+              {'<<>>'} •&nbsp;
             </>
           )}
 

--- a/src/frontend/apps/e2e/__tests__/app-desk/footer.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/footer.spec.ts
@@ -90,10 +90,6 @@ test.describe('Footer', () => {
 
   test('check if the app version is visible', async ({ page }) => {
     const footer = page.locator('footer').first();
-    await expect(
-      footer.getByText(
-        'Version: NA • Unless otherwise stated, all content on this site is under',
-      ),
-    ).toBeVisible();
+    await expect(footer.getByText('Version:')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose

Display version information in the app's footer to help acceptance testing and debugging.

Fixes #510 

## Proposal

Improve release script to generate the version.json file that helps the frontend show a version number via the config endpoint, also embed the commit hash directly in frontend to serve as a sanity check in case the frontend fails to build.
