### PR TITLE
🐛(mail) fix button display on outlook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(mail) fix display button on outlook
 - 💚(ci) improve E2E tests #492
 - 🔧(sentry) restore default integrations
 - 🔇(backend) remove Sentry duplicated warning/errors

--- a/src/mail/mjml/new_mailbox.mjml
+++ b/src/mail/mjml/new_mailbox.mjml
@@ -26,7 +26,7 @@
       </mj-section>
       <mj-section padding="0px 20px">
         <mj-column>
-          <mj-button href="//{{ webmail_url }}" background-color="#000091" color="white" padding="30px 0px">
+          <mj-button background-color="#000091" color="white" href="{{ webmail_url }}">
             {% trans "Go to La Messagerie" %}
           </mj-button>
           <!-- Signature -->


### PR DESCRIPTION
In confirmation email of mailbox creation,
button "Go to La Messagerie" disappears on Outlook. We try to fix here this display bug.
