### PR TITLE
Create version.json files on both backend and frontend on push

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -87,6 +87,13 @@ jobs:
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
         run: echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+      - name: create-version-json
+        id: create-version-json
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "version.json"
+          json: '{"source":"${{github.repository}}", "version":"${{github.ref_name}}", "commit":"${{github.sha}}", "build": "NA"}'
+          dir: 'src/backend'
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -127,6 +134,13 @@ jobs:
         with:
           secret-file: secrets/numerique-gouv/people/secrets.enc.env
           age-key: ${{ secrets.SOPS_PRIVATE }}
+      - name: create-version-json
+        id: create-version-json
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "version.json"
+          json: '{"source":"${{github.repository}}", "version":"${{github.ref_name}}", "commit":"${{github.sha}}", "build": "NA"}'
+          dir: 'src/frontend/apps/desk'
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -504,7 +504,7 @@ class ConfigView(views.APIView):
         GET /api/v1.0/config/
             Return a dictionary of public settings.
         """
-        array_settings = ["LANGUAGES", "FEATURES", "RELEASE"]
+        array_settings = ["LANGUAGES", "FEATURES", "RELEASE", "COMMIT"]
         dict_settings = {}
         for setting in array_settings:
             dict_settings[setting] = getattr(settings, setting)

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -20,6 +20,7 @@ def test_api_config_anonymous():
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
         "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"]],
+        "COMMIT": "NA",
         "FEATURES": {
             "CONTACTS_DISPLAY": True,
             "CONTACTS_CREATE": True,
@@ -42,6 +43,7 @@ def test_api_config_authenticated():
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
         "LANGUAGES": [["en-us", "English"], ["fr-fr", "French"]],
+        "COMMIT": "NA",
         "FEATURES": {
             "CONTACTS_DISPLAY": True,
             "CONTACTS_CREATE": True,

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -44,6 +44,17 @@ def get_release():
         return "NA"  # Default: not available
 
 
+def get_commit():
+    """
+    Get the current commit of the application
+    """
+    try:
+        with open(os.path.join(BASE_DIR, "version.json"), encoding="utf8") as version:
+            return json.load(version)["commit"]
+    except FileNotFoundError:
+        return "NA"  # Default: not available
+
+
 class Base(Configuration):
     """
     This is the base configuration every configuration (aka environment) should inherit from. It
@@ -487,6 +498,14 @@ class Base(Configuration):
         Delegate to the module function to enable easier testing.
         """
         return get_release()
+
+    # pylint: disable=invalid-name
+    @property
+    def COMMIT(self):
+        """
+        Return the commit information.
+        """
+        return get_commit()
 
     # pylint: disable=invalid-name
     @property

--- a/src/frontend/apps/desk/.prettierignore
+++ b/src/frontend/apps/desk/.prettierignore
@@ -1,1 +1,2 @@
 next-env.d.ts
+version.json

--- a/src/frontend/apps/desk/src/__tests__/pages.test.tsx
+++ b/src/frontend/apps/desk/src/__tests__/pages.test.tsx
@@ -23,6 +23,7 @@ describe('Page', () => {
     useConfigStore.setState({
       config: {
         RELEASE: '1.0.0',
+        COMMIT: 'NA',
         FEATURES: { TEAMS_DISPLAY: true },
         LANGUAGES: [],
       },
@@ -37,6 +38,7 @@ describe('Page', () => {
     useConfigStore.setState({
       config: {
         RELEASE: '1.0.0',
+        COMMIT: 'NA',
         FEATURES: { TEAMS_DISPLAY: false },
         LANGUAGES: [],
       },

--- a/src/frontend/apps/desk/src/core/__tests__/MainLayout.test.tsx
+++ b/src/frontend/apps/desk/src/core/__tests__/MainLayout.test.tsx
@@ -20,6 +20,7 @@ describe('MainLayout', () => {
     useConfigStore.setState({
       config: {
         RELEASE: '1.0.0',
+        COMMIT: 'NA',
         FEATURES: { TEAMS_DISPLAY: true },
         LANGUAGES: [],
       },
@@ -57,6 +58,7 @@ describe('MainLayout', () => {
     useConfigStore.setState({
       config: {
         RELEASE: '1.0.0',
+        COMMIT: 'NA',
         FEATURES: { TEAMS_DISPLAY: true },
         LANGUAGES: [],
       },
@@ -95,6 +97,7 @@ describe('MainLayout', () => {
     useConfigStore.setState({
       config: {
         RELEASE: '1.0.0',
+        COMMIT: 'NA',
         FEATURES: { TEAMS_DISPLAY: false },
         LANGUAGES: [],
       },

--- a/src/frontend/apps/desk/src/core/config/types.ts
+++ b/src/frontend/apps/desk/src/core/config/types.ts
@@ -1,6 +1,7 @@
 export interface Config {
   LANGUAGES: [string, string][];
   RELEASE: string;
+  COMMIT: string;
   FEATURES: {
     TEAMS_DISPLAY: boolean;
   };

--- a/src/frontend/apps/desk/src/features/footer/Footer.tsx
+++ b/src/frontend/apps/desk/src/features/footer/Footer.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { Box, LogoGouv, StyledLink, Text } from '@/components';
 import { useConfigStore } from '@/core';
 
+import frontVersion from '../../../version.json';
+
 import IconLink from './assets/external-link.svg';
 
 const BlueStripe = styled.div`
@@ -140,6 +142,11 @@ export const Footer = () => {
             </StyledLink>
           ))}
         </Box>
+
+        <Text as="p" aria-hidden="true" $css="display: none">
+          You have found the hidden app version information ! Well done ! back
+          commit is: {config?.COMMIT}; front commit is: {frontVersion?.commit}
+        </Text>
 
         <Text
           as="p"

--- a/src/frontend/apps/desk/version.json
+++ b/src/frontend/apps/desk/version.json
@@ -1,0 +1,6 @@
+{
+    "source":"people",
+    "version":"version",
+    "commit":"commit",
+    "build": "NA"
+}

--- a/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/config.spec.ts
@@ -20,6 +20,7 @@ test.describe('Config', () => {
         ['en-us', 'English'],
         ['fr-fr', 'French'],
       ],
+      COMMIT: 'NA',
       FEATURES: {
         CONTACTS_CREATE: true,
         CONTACTS_DISPLAY: true,


### PR DESCRIPTION
## Purpose

Display version information in the app's footer to help acceptance testing and debugging.

Fixes #510

## Proposal

This supplements the release process. We inject Github metadata into two version.json files; the 'version' value will be filled with `github.ref_name`, which will depend on the type of event, for release tag events it should be the same as the release tag (i.e. the app version). This should make version information available to the /config endpoint on any push, and the frontend should display the backend version.

Relevant documentation: [Accessing contextual information about workflow runs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)