### PR TITLE
🐛(mailboxes) fix logic when attempting to duplicate mailboxes

### DIFF
--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -68,8 +68,8 @@ class DimailAPIClient:
 
         if response.status_code == status.HTTP_403_FORBIDDEN:
             logger.error(
-                "[DIMAIL] 403 Forbidden: Could not retrieve a token,\
-                please check 'MAIL_PROVISIONING_API_CREDENTIALS' setting.",
+                "[DIMAIL] 403 Forbidden: Could not retrieve a token,"
+                "please check 'MAIL_PROVISIONING_API_CREDENTIALS' setting.",
             )
             raise exceptions.PermissionDenied(
                 "Token denied. Please check your MAIL_PROVISIONING_API_CREDENTIALS."


### PR DESCRIPTION
## Purpose

Logic was broken when attempting to duplicate mailboxes, where infos were sent to dimail before checking for uniqueness.


## Proposal

I'd rather add this logic to a `validate` function in serializer, but that would require some heavier refacto (addition of domain in serializer or at least in context)
