### PR TITLE
✨(dimail) automate allows requests to dimail when creating domain accesses

### DIFF
--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -197,6 +197,10 @@ jobs:
         run: |
           make demo FLUSH_ARGS='--no-input'
 
+      - name: Setup Dimail DB
+        run: |
+          make dimail-setup-db
+
       - name: Install Playwright Browsers
         run: cd src/frontend/apps/e2e && yarn install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(dimail) automate allows requests to dimail
 -  ✨(contacts) add notes & force full_name #565
 
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
 
   dimail: 
     entrypoint: /opt/dimail-api/start-dev.sh
-    image: registry.mim-libre.fr/dimail/dimail-api:v0.0.13
+    image: registry.mim-libre.fr/dimail/dimail-api:v0.0.16
     pull_policy: always
     environment:
       DIMAIL_MODE: FAKE

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -51,10 +51,12 @@ class MailDomainViewSet(
         """Set the current user as owner of the newly created mail domain."""
 
         domain = serializer.save()
-        models.MailDomainAccess.objects.create(
-            user=self.request.user,
-            domain=domain,
-            role=core_models.RoleChoices.OWNER,
+        serializers.MailDomainAccessSerializer().create(
+            validated_data={
+                "user": self.request.user,
+                "domain": domain,
+                "role": str(core_models.RoleChoices.OWNER),
+            }
         )
 
 

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
@@ -2,9 +2,12 @@
 Test for mail domain accesses API endpoints in People's core app : create
 """
 
+import logging
 import random
+import re
 
 import pytest
+import responses
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -105,15 +108,16 @@ def test_api_mail_domain__accesses_create_authenticated_administrator():
     client = APIClient()
     client.force_login(authenticated_user)
 
-    # It should not be allowed to create an owner access
-    response = client.post(
-        f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-        {
-            "user": str(other_user.id),
-            "role": enums.MailDomainRoleChoices.OWNER,
-        },
-        format="json",
-    )
+    with responses.RequestsMock() as rsps:
+        # It should not be allowed to create an owner access
+        response = client.post(
+            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+            {
+                "user": str(other_user.id),
+                "role": enums.MailDomainRoleChoices.OWNER,
+            },
+            format="json",
+        )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {
@@ -123,14 +127,38 @@ def test_api_mail_domain__accesses_create_authenticated_administrator():
     # It should be allowed to create a lower access
     for role in [enums.MailDomainRoleChoices.ADMIN, enums.MailDomainRoleChoices.VIEWER]:
         other_user = core_factories.UserFactory()
-        response = client.post(
-            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-            {
-                "user": str(other_user.id),
-                "role": role,
-            },
-            format="json",
-        )
+        with responses.RequestsMock() as rsps:
+            if role != enums.MailDomainRoleChoices.VIEWER:
+                # viewers don't have allows in dimail
+                rsps.add(
+                    rsps.POST,
+                    re.compile(r".*/users/"),
+                    body=str(
+                        {
+                            "name": str(other_user.sub),
+                            "is_admin": "false",
+                            "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
+                            "perms": [],
+                        }
+                    ),
+                    status=status.HTTP_201_CREATED,
+                    content_type="application/json",
+                )
+                rsps.add(
+                    rsps.POST,
+                    re.compile(r".*/allows/"),
+                    body=str({"user": other_user.sub, "domain": str(mail_domain.name)}),
+                    status=status.HTTP_201_CREATED,
+                    content_type="application/json",
+                )
+            response = client.post(
+                f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+                {
+                    "user": str(other_user.id),
+                    "role": role,
+                },
+                format="json",
+            )
         assert response.status_code == status.HTTP_201_CREATED
         new_mail_domain_access = models.MailDomainAccess.objects.filter(
             user=other_user
@@ -150,19 +178,41 @@ def test_api_mail_domain__accesses_create_authenticated_owner():
         users=[(authenticated_user, enums.MailDomainRoleChoices.OWNER)]
     )
     other_user = core_factories.UserFactory()
-
     role = random.choice([role[0] for role in enums.MailDomainRoleChoices.choices])
 
     client = APIClient()
     client.force_login(authenticated_user)
-    response = client.post(
-        f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
-        {
-            "user": str(other_user.id),
-            "role": role,
-        },
-        format="json",
-    )
+    with responses.RequestsMock() as rsps:
+        if role != enums.MailDomainRoleChoices.VIEWER:
+            rsps.add(
+                rsps.POST,
+                re.compile(r".*/users/"),
+                body=str(
+                    {
+                        "name": str(other_user.sub),
+                        "is_admin": "false",
+                        "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
+                        "perms": [],
+                    }
+                ),
+                status=status.HTTP_201_CREATED,
+                content_type="application/json",
+            )
+            rsps.add(
+                rsps.POST,
+                re.compile(r".*/allows/"),
+                body=str({"user": other_user.sub, "domain": str(mail_domain.name)}),
+                status=status.HTTP_201_CREATED,
+                content_type="application/json",
+            )
+        response = client.post(
+            f"/api/v1.0/mail-domains/{mail_domain.slug}/accesses/",
+            {
+                "user": str(other_user.id),
+                "role": role,
+            },
+            format="json",
+        )
 
     assert response.status_code == status.HTTP_201_CREATED
     assert models.MailDomainAccess.objects.filter(user=other_user).count() == 1
@@ -171,3 +221,149 @@ def test_api_mail_domain__accesses_create_authenticated_owner():
     ).get()
     assert response.json()["id"] == str(new_mail_domain_access.id)
     assert response.json()["role"] == role
+
+
+## INTEROP WITH DIMAIL
+def test_api_mail_domains_accesses__create_dimail_allows(caplog):
+    """
+    Creating a domain access on our API should trigger a request to create an access on dimail too.
+    """
+    caplog.set_level(logging.INFO)
+
+    authenticated_user = core_factories.UserFactory()
+    domain = factories.MailDomainFactory(status="enabled")
+    factories.MailDomainAccessFactory(
+        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
+    )
+    client = APIClient()
+    client.force_login(authenticated_user)
+
+    allowed_user = core_factories.UserFactory()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.POST,
+            re.compile(r".*/users/"),
+            body=str(
+                {
+                    "name": str(allowed_user.sub),
+                    "is_admin": "false",
+                    "uuid": "71f60d74-a3ad-46bc-bc2b-20d79a2e36fb",
+                    "perms": [],
+                }
+            ),
+            status=status.HTTP_201_CREATED,
+            content_type="application/json",
+        )
+        rsps.add(
+            rsps.POST,
+            re.compile(r".*/allows/"),
+            body=str({"user": allowed_user.sub, "domain": str(domain.name)}),
+            status=status.HTTP_201_CREATED,
+            content_type="application/json",
+        )
+        response = client.post(
+            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
+            {
+                "user": str(allowed_user.id),
+                "role": enums.MailDomainRoleChoices.ADMIN,
+            },
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # check logs
+    assert (
+        caplog.records[0].message
+        == f'[DIMAIL] User "{allowed_user.sub}" successfully created on dimail'
+    )
+    assert (
+        caplog.records[1].message
+        == f'[DIMAIL] Permissions granted for user "{allowed_user.sub}" on domain {domain.name}.'
+    )
+
+
+def test_api_mail_domains_accesses__dont_create_dimail_allows_for_viewer(caplog):
+    """Dimail should not be called when creating an access to a simple viewer."""
+    caplog.set_level(logging.INFO)
+
+    authenticated_user = core_factories.UserFactory()
+    domain = factories.MailDomainFactory(status="enabled")
+    factories.MailDomainAccessFactory(
+        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
+    )
+    client = APIClient()
+    client.force_login(authenticated_user)
+
+    allowed_user = core_factories.UserFactory()
+    with responses.RequestsMock():
+        # No call expected
+        response = client.post(
+            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
+            {
+                "user": str(allowed_user.id),
+                "role": enums.MailDomainRoleChoices.VIEWER,
+            },
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # check logs
+    assert len(caplog.records) == 1  # should be 0, investigate this damn empty message
+
+
+def test_api_mail_domains_accesses__user_already_on_dimail(caplog):
+    """The expected allow should be created when an user already exists on dimail
+    (i.e. previous admin/owner of same domain or current on another domain)."""
+    caplog.set_level(logging.INFO)
+
+    authenticated_user = core_factories.UserFactory()
+    domain = factories.MailDomainFactory()
+    factories.MailDomainAccessFactory(
+        domain=domain, user=authenticated_user, role=enums.MailDomainRoleChoices.OWNER
+    )
+    client = APIClient()
+    client.force_login(authenticated_user)
+
+    allowed_user = core_factories.UserFactory()
+
+    with responses.RequestsMock() as rsps:
+        # No call expected
+        rsps.add(
+            rsps.POST,
+            re.compile(r".*/users/"),
+            body=str(
+                {"detail": "User already exists"}
+            ),  # the user is already on dimail
+            status=status.HTTP_409_CONFLICT,
+            content_type="application/json",
+        )
+        rsps.add(
+            rsps.POST,
+            re.compile(r".*/allows/"),
+            body=str({"user": allowed_user.sub, "domain": str(domain.name)}),
+            status=status.HTTP_201_CREATED,
+            content_type="application/json",
+        )
+        response = client.post(
+            f"/api/v1.0/mail-domains/{domain.slug}/accesses/",
+            {
+                "user": str(allowed_user.id),
+                "role": enums.MailDomainRoleChoices.ADMIN,
+            },
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    # check logs
+    assert len(caplog.records) == 3  # should be 2, investigate this damn empty message
+    assert (
+        caplog.records[0].message
+        == f'[DIMAIL] Attempt to create user "{allowed_user.sub}" which already exists.'
+    )
+    assert (
+        caplog.records[1].message
+        == f'[DIMAIL] Permissions granted for user "{allowed_user.sub}" on domain {domain.name}.'
+    )


### PR DESCRIPTION
## Purpose

Automatically send user creation and allow creation requests to dimail
upon creating domain access.

## Proposal

Description...

- [x] client function to send user creation request
- [x] client fuction to send allow creation request
- [x] test basic case for admin/owner
- [x] test basic case for viewer (no call made)
- [x] test wen user already exists
- [x] make sure it triggers when creating a domain !
- [ ] handle update of existing domain access + test OK when user goes from viewer to admin/owner (in another PR ?) 