### PR TITLE
🚑️(backend) fix claim contains non user field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - 🩹(mailbox) fix status of current mailboxes
+- 🚑️(backend) fix claim contains non-user field #548
 
 ## [1.6.0] - 2024-11-20
 

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -220,13 +220,11 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
 
     def update_user_if_needed(self, user, claims):
         """Update user claims if they have changed."""
-        has_changed = any(
-            value and value != getattr(user, key)
-            for key, value in claims.items()
-            if key != "sub"
-        )
-        if has_changed:
-            updated_claims = {
-                key: value for key, value in claims.items() if value and key != "sub"
-            }
+        updated_claims = {}
+        for key in ["email", "name"]:
+            claim_value = claims.get(key)
+            if claim_value and claim_value != getattr(user, key):
+                updated_claims[key] = claim_value
+
+        if updated_claims:
             self.UserModel.objects.filter(sub=user.sub).update(**updated_claims)


### PR DESCRIPTION
## Purpose

When we use the feature to get Organization registration number, the claim contains this value and it does not match with any user field.

BUG seen in [LA-REGIE-BACKEND-16](https://sentry.incubateur.net/organizations/betagouv/issues/133323/)


## Proposal

I switched to a whitelist instead of a blacklist (and two loops, with an if condition on each)

- [x] Rewrite the `update_user_if_needed` for simplification
- [x] Test the organization registration number in claim does not break user update

