### PR TITLE
✨(organization) add API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(mailbox) allow to disable mailbox
 - ✨(backend) add ServiceProvider #522
 - 💄(admin) allow header color customization #552 
+- ✨(organization) add API endpoints #551
 
 ### Fixed
 

--- a/src/backend/core/api/client/serializers.py
+++ b/src/backend/core/api/client/serializers.py
@@ -51,6 +51,24 @@ class DynamicFieldsModelSerializer(serializers.ModelSerializer):
                 self.fields.pop(field_name)
 
 
+class OrganizationSerializer(serializers.ModelSerializer):
+    """Serialize organizations."""
+
+    abilities = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Organization
+        fields = ["id", "name", "registration_id_list", "domain_list", "abilities"]
+        read_only_fields = ["id", "registration_id_list", "domain_list"]
+
+    def get_abilities(self, organization) -> dict:
+        """Return abilities of the logged-in user on the instance."""
+        request = self.context.get("request")
+        if request:
+            return organization.get_abilities(request.user)
+        return {}
+
+
 class UserSerializer(DynamicFieldsModelSerializer):
     """Serialize users."""
 

--- a/src/backend/core/api/client/serializers.py
+++ b/src/backend/core/api/client/serializers.py
@@ -69,12 +69,22 @@ class OrganizationSerializer(serializers.ModelSerializer):
         return {}
 
 
+class UserOrganizationSerializer(serializers.ModelSerializer):
+    """Serialize organizations for users."""
+
+    class Meta:
+        model = models.Organization
+        fields = ["id", "name"]
+        read_only_fields = ["id", "name"]
+
+
 class UserSerializer(DynamicFieldsModelSerializer):
     """Serialize users."""
 
     timezone = TimeZoneSerializerField(use_pytz=False, required=True)
     email = serializers.ReadOnlyField()
     name = serializers.ReadOnlyField()
+    organization = UserOrganizationSerializer(read_only=True)
 
     class Meta:
         model = models.User
@@ -83,6 +93,7 @@ class UserSerializer(DynamicFieldsModelSerializer):
             "email",
             "language",
             "name",
+            "organization",
             "timezone",
             "is_device",
             "is_staff",
@@ -98,6 +109,7 @@ class UserMeSerializer(UserSerializer):
     """
 
     abilities = serializers.SerializerMethodField()
+    organization = UserOrganizationSerializer(read_only=True)
 
     class Meta:
         model = models.User
@@ -108,6 +120,7 @@ class UserMeSerializer(UserSerializer):
             "is_staff",
             "language",
             "name",
+            "organization",
             "timezone",
             # added fields
             "abilities",

--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -225,7 +225,9 @@ class UserViewSet(
     """
 
     permission_classes = [permissions.IsSelf]
-    queryset = models.User.objects.all().order_by("-created_at")
+    queryset = (
+        models.User.objects.select_related("organization").all().order_by("-created_at")
+    )
     serializer_class = serializers.UserSerializer
     get_me_serializer_class = serializers.UserMeSerializer
     throttle_classes = [BurstRateThrottle, SustainedRateThrottle]

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -138,6 +138,22 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
         )
 
 
+class OrganizationAccessFactory(factory.django.DjangoModelFactory):
+    """Factory to create organization accesses for testing purposes."""
+
+    class Meta:
+        model = models.OrganizationAccess
+
+    user = factory.SubFactory(
+        "core.factories.UserFactory",
+        organization=factory.SelfAttribute("..organization"),
+    )
+    organization = factory.SubFactory(
+        "core.factories.OrganizationFactory", with_registration_id=True
+    )
+    role = factory.fuzzy.FuzzyChoice(models.OrganizationRoleChoices.values)
+
+
 class UserFactory(factory.django.DjangoModelFactory):
     """A factory to create random users for testing purposes."""
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -359,14 +359,8 @@ class Organization(BaseModel):
         """
         Compute and return abilities for a given user on the organization.
         """
-        try:
-            # Use the role from queryset annotation if available
-            is_admin = self.user_role == OrganizationRoleChoices.ADMIN
-        except AttributeError:
-            is_admin = self.organization_accesses.filter(
-                user=user,
-                role=OrganizationRoleChoices.ADMIN,
-            ).exists()
+        # Use the role from queryset annotation will raise on purpose if not used properly
+        is_admin = self.user_role == OrganizationRoleChoices.ADMIN  # pylint: disable=no-member
 
         return {
             "get": user.organization_id == self.pk,

--- a/src/backend/core/tests/organizations/__init__.py
+++ b/src/backend/core/tests/organizations/__init__.py
@@ -1,0 +1,1 @@
+"""Test organization API endpoints."""

--- a/src/backend/core/tests/organizations/test_core_api_organizations_retrieve.py
+++ b/src/backend/core/tests/organizations/test_core_api_organizations_retrieve.py
@@ -1,0 +1,91 @@
+"""
+Tests for Organizations API endpoint in People's core app: retrieve
+"""
+
+import pytest
+from rest_framework import status
+
+from core import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_organizations_retrieve_anonymous(client):
+    """Anonymous users should not be allowed to retrieve an organization."""
+    organization = factories.OrganizationFactory(with_registration_id=True)
+    response = client.get(f"/api/v1.0/organizations/{organization.pk}/")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+def test_api_organizations_retrieve_authenticated_unrelated(client):
+    """
+    Authenticated users should not be allowed to retrieve an organization to which they are
+    not related.
+    """
+    user = factories.UserFactory()
+    organization = factories.OrganizationFactory(with_registration_id=True)
+
+    client.force_login(user)
+
+    response = client.get(
+        f"/api/v1.0/organizations/{organization.pk!s}/",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "No Organization matches the given query."}
+
+
+def test_api_organizations_retrieve_authenticated_belong_to_organization(client):
+    """
+    Authenticated users should be allowed to retrieve an organization to which they
+    belong to.
+    """
+    organization = factories.OrganizationFactory(
+        registration_id_list=["56618615316840", "31561861231231", "98781236231482"],
+        domain_list=["example.com", "example.org"],
+    )
+    user = factories.UserFactory(organization=organization)
+
+    client.force_login(user)
+
+    response = client.get(
+        f"/api/v1.0/organizations/{organization.pk!s}/",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "id": str(organization.pk),
+        "name": organization.name,
+        "abilities": {"delete": False, "get": True, "patch": False, "put": False},
+        "domain_list": ["example.com", "example.org"],
+        "registration_id_list": ["56618615316840", "31561861231231", "98781236231482"],
+    }
+
+
+def test_api_organizations_retrieve_authenticated_administrator(client):
+    """
+    Authenticated users should be allowed to retrieve an organization
+    which they administrate.
+    """
+    organization_access = (
+        factories.OrganizationAccessFactory()
+    )  # only role is administrator for now
+    user = organization_access.user
+    organization = organization_access.organization
+
+    client.force_login(user)
+
+    response = client.get(
+        f"/api/v1.0/organizations/{organization.pk!s}/",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["abilities"] == {
+        "delete": False,
+        "get": True,
+        "patch": True,
+        "put": True,
+    }

--- a/src/backend/core/tests/organizations/test_core_api_organizations_update.py
+++ b/src/backend/core/tests/organizations/test_core_api_organizations_update.py
@@ -1,0 +1,96 @@
+"""
+Tests for Organizations API endpoint in People's core app: update
+"""
+
+import pytest
+from rest_framework import status
+
+from core import factories
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_organizations_update_anonymous(client):
+    """Anonymous users should not be allowed to update an organization."""
+    organization = factories.OrganizationFactory(with_registration_id=True)
+    response = client.patch(
+        f"/api/v1.0/organizations/{organization.pk}/",
+        {"name": "New Name"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {
+        "detail": "Authentication credentials were not provided."
+    }
+
+
+def test_api_organizations_update_authenticated_unrelated(client):
+    """
+    Authenticated users should not be allowed to update an organization to which they are
+    not related.
+    """
+    user = factories.UserFactory()
+    organization = factories.OrganizationFactory(with_registration_id=True)
+
+    client.force_login(user)
+
+    response = client.patch(
+        f"/api/v1.0/organizations/{organization.pk}/",
+        {"name": "New Name"},
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "No Organization matches the given query."}
+
+
+def test_api_organizations_update_authenticated_belong_to_organization(client):
+    """
+    Authenticated users should NOT be allowed to update an organization to which they
+    belong to.
+    """
+    organization = factories.OrganizationFactory(with_registration_id=True)
+    user = factories.UserFactory(organization=organization)
+
+    client.force_login(user)
+
+    response = client.patch(
+        f"/api/v1.0/organizations/{organization.pk}/",
+        {"name": "New Name"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "detail": "You do not have permission to perform this action."
+    }
+
+
+def test_api_organizations_update_authenticated_administrator(client):
+    """
+    Authenticated users should be allowed to update an organization
+    which they administrate.
+    """
+    organization = factories.OrganizationFactory(
+        registration_id_list=["56618615316840", "31561861231231", "98781236231482"],
+        domain_list=["example.com", "example.org"],
+    )
+    organization_access = factories.OrganizationAccessFactory(organization=organization)
+    user = organization_access.user
+
+    client.force_login(user)
+
+    response = client.patch(
+        f"/api/v1.0/organizations/{organization.pk}/",
+        {"name": "New Name"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "id": str(organization.pk),
+        "name": "New Name",
+        "abilities": {"delete": False, "get": True, "patch": True, "put": True},
+        "domain_list": ["example.com", "example.org"],
+        "registration_id_list": ["56618615316840", "31561861231231", "98781236231482"],
+    }

--- a/src/backend/people/api_urls.py
+++ b/src/backend/people/api_urls.py
@@ -12,6 +12,7 @@ from core.resource_server.urls import urlpatterns as resource_server_urls
 # - Main endpoints
 router = DefaultRouter()
 router.register("contacts", viewsets.ContactViewSet, basename="contacts")
+router.register("organizations", viewsets.OrganizationViewSet, basename="organizations")
 router.register("teams", viewsets.TeamViewSet, basename="teams")
 router.register("users", viewsets.UserViewSet, basename="users")
 router.register(


### PR DESCRIPTION
## Purpose

This provides a way to get information about organization and update their name for administrators.
This will allow the frontend to display data about organization when displaying a user or a list of users.


## Proposal

Add `Organization` serializers and viewset. The frontend integration will be done later (when we know were we want to display any of this).

- [x] Add organizations endpoints
- [x] Add organization PK and name in the user endpoints
