### PR TITLE
💄(admin) allow header color customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(backend) add ServiceProvider #522
+- 💄(admin) allow header color customization #552 
 
 ### Fixed
 

--- a/src/backend/admin/__init__.py
+++ b/src/backend/admin/__init__.py
@@ -1,0 +1,1 @@
+"""People custom admin site."""

--- a/src/backend/admin/apps.py
+++ b/src/backend/admin/apps.py
@@ -1,0 +1,9 @@
+"""Custom Django admin site application configuration."""
+
+from django.contrib.admin.apps import AdminConfig
+
+
+class PeopleAdminConfig(AdminConfig):
+    """Declare our custom Django admin site."""
+
+    default_site = "admin.sites.PeopleAdminSite"

--- a/src/backend/admin/sites.py
+++ b/src/backend/admin/sites.py
@@ -1,0 +1,15 @@
+"""Custom Django admin site for the People app."""
+
+from django.conf import settings
+from django.contrib import admin
+
+
+class PeopleAdminSite(admin.AdminSite):
+    """People custom admin site."""
+
+    def each_context(self, request):
+        """Add custom context to the admin site."""
+        return super().each_context(request) | {
+            "ADMIN_HEADER_BACKGROUND": settings.ADMIN_HEADER_BACKGROUND,
+            "ADMIN_HEADER_COLOR": settings.ADMIN_HEADER_COLOR,
+        }

--- a/src/backend/admin/templates/admin/base_site.html
+++ b/src/backend/admin/templates/admin/base_site.html
@@ -1,0 +1,10 @@
+{% extends "admin/base_site.html" %}
+
+{% block extrastyle %}{{ block.super }}
+<style>
+html[data-theme="light"], :root {
+  {% if ADMIN_HEADER_BACKGROUND %}--header-bg: {{ ADMIN_HEADER_BACKGROUND }};{% endif %}
+  {% if ADMIN_HEADER_COLOR %}--header-color: {{ ADMIN_HEADER_COLOR }};{% endif %}
+}
+</style>
+{% endblock %}

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -158,7 +158,12 @@ class Base(Configuration):
     TEMPLATES = [
         {
             "BACKEND": "django.template.backends.django.DjangoTemplates",
-            "DIRS": [os.path.join(BASE_DIR, "templates")],
+            "DIRS": [
+                os.path.join(BASE_DIR, "templates"),
+                os.path.join(
+                    BASE_DIR, "admin", "templates"
+                ),  # enforce load before Django's admin
+            ],
             "OPTIONS": {
                 "context_processors": [
                     "django.contrib.auth.context_processors.auth",
@@ -200,6 +205,7 @@ class Base(Configuration):
     # Django's applications from the highest priority to the lowest
     INSTALLED_APPS = [
         # People
+        "admin.apps.PeopleAdminConfig",  # replaces 'django.contrib.admin'
         "core",
         "demo",
         "mailbox_manager",
@@ -211,7 +217,6 @@ class Base(Configuration):
         "parler",
         "easy_thumbnails",
         # Django
-        "django.contrib.admin",
         "django.contrib.auth",
         "django.contrib.contenttypes",
         "django.contrib.postgres",
@@ -276,6 +281,10 @@ class Base(Configuration):
         "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
         "REDOC_DIST": "SIDECAR",
     }
+
+    # Django Admin
+    ADMIN_HEADER_BACKGROUND = values.Value(None)
+    ADMIN_HEADER_COLOR = values.Value(None)
 
     # Mail
     EMAIL_BACKEND = values.Value("django.core.mail.backends.smtp.EmailBackend")

--- a/src/helm/env.d/production/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/production/values.desk.yaml.gotmpl
@@ -8,6 +8,8 @@ backend:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   envVars:
+    DJANGO_ADMIN_HEADER_BACKGROUND: "#dc3545"
+    DJANGO_ADMIN_HEADER_COLOR: "#ffffff"
     DJANGO_CSRF_TRUSTED_ORIGINS: https://regie.numerique.gouv.fr
     DJANGO_CONFIGURATION: Production
     DJANGO_ALLOWED_HOSTS: "*"

--- a/src/helm/env.d/staging/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.desk.yaml.gotmpl
@@ -8,6 +8,8 @@ backend:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   envVars:
+    DJANGO_ADMIN_HEADER_BACKGROUND: "#0f5132"
+    DJANGO_ADMIN_HEADER_COLOR: "#ffffff"
     DJANGO_CSRF_TRUSTED_ORIGINS: http://desk-staging.beta.numerique.gouv.fr,https://desk-staging.beta.numerique.gouv.fr
     DJANGO_CONFIGURATION: Production
     DJANGO_ALLOWED_HOSTS: "*"


### PR DESCRIPTION
## Purpose

This allows to use custom colors according to environment.

FIXES #430


## Proposal

- [x] add a custom Django admin site
- [x] pass Django admin header colors through context
