### PR TITLE
🐛(admin) add organization on user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) add ServiceProvider #522
+
 ### Fixed
 
 -  🐛(admin) add organization on user #555
@@ -29,7 +33,6 @@ and this project adheres to
 
 - ✨(domains) allow creation of "pending" mailboxes
 - ✨(teams) allow team management for team admins/owners #509
-- ✨(backend) add ServiceProvider #522
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+-  🐛(admin) add organization on user #555
+
 ## [1.6.1] - 2024-11-22
 
 ### Fixed

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -49,6 +49,7 @@ class UserAdmin(auth_admin.UserAdmin):
                     "id",
                     "sub",
                     "password",
+                    "organization",
                 )
             },
         ),


### PR DESCRIPTION
## Purpose

User fields has to be listed, this one was forgotten in the "add organization" commit...


## Proposal

- [x] Add organization field in `User` admin.
