### PR TITLE
Add siret attribute and mapper to Keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 🧑‍💻(oidc) add ability to pull registration ID (e.g. SIRET) from OIDC #577
+
 ### Fixed
 
 - 🧑‍💻(user) fix the User.language infinite migration #611

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -59,7 +59,7 @@
       "realmRoles": ["user"]
     },
     {
-      "username": "marie",
+      "username": "e2e.marie",
       "email": "marie.varzy@gmail.com",
       "firstName": "Marie",
       "lastName": "Devarzy",
@@ -70,7 +70,7 @@
       "credentials": [
         {
           "type": "password",
-          "value": "people"
+          "value": "password-e2e.marie"
         }
       ],
       "realmRoles": ["user"]

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -59,6 +59,23 @@
       "realmRoles": ["user"]
     },
     {
+      "username": "marie",
+      "email": "marie.varzy@gmail.com",
+      "firstName": "Marie",
+      "lastName": "Devarzy",
+      "enabled": true,
+      "attributes": {
+          "siret": "21580304000017"
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "people"
+        }
+      ],
+      "realmRoles": ["user"]
+    },
+    {
       "username": "user-e2e-chromium",
       "email": "user@chromium.e2e",
       "firstName": "E2E",
@@ -696,8 +713,16 @@
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
   "scopeMappings": [
     {
+      "clientScope": "siret",
+      "roles": [
+        "user"
+      ]
+    },
+    {
       "clientScope": "offline_access",
-      "roles": ["offline_access"]
+      "roles": [
+        "offline_access"
+      ]
     }
   ],
   "clientScopeMappings": {
@@ -947,6 +972,7 @@
         "acr",
         "roles",
         "profile",
+        "siret",
         "email"
       ],
       "optionalClientScopes": [
@@ -1103,6 +1129,35 @@
             "claim.name": "realm_access.roles",
             "jsonType.label": "String",
             "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "eb220fbb-02ac-4105-95a3-727954f6565d",
+      "name": "siret",
+      "description": "siret",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false",
+        "gui.order": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "333a4e89-9363-4c36-b56f-79c6b019c6c6",
+          "name": "siret",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "userinfo.token.claim": "true",
+            "multivalued": "false",
+            "user.attribute": "siret",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "siret"
           }
         }
       ]
@@ -1573,7 +1628,8 @@
     "email",
     "roles",
     "web-origins",
-    "acr"
+    "acr",
+    "siret"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",

--- a/src/backend/core/api/client/serializers.py
+++ b/src/backend/core/api/client/serializers.py
@@ -88,8 +88,8 @@ class UserOrganizationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Organization
-        fields = ["id", "name"]
-        read_only_fields = ["id", "name"]
+        fields = ["id", "name", "registration_id_list"]
+        read_only_fields = ["id", "name", "registration_id_list"]
 
 
 class UserSerializer(DynamicFieldsModelSerializer):

--- a/src/backend/core/tests/users/test_api_users_list.py
+++ b/src/backend/core/tests/users/test_api_users_list.py
@@ -4,6 +4,7 @@ Test users API endpoints in the People core app: focus on "list" action
 
 from unittest import mock
 
+import jq
 import pytest
 from rest_framework.status import (
     HTTP_200_OK,
@@ -77,7 +78,13 @@ def test_api_users_list_authenticated_response_content(
         response = client.get("/api/v1.0/users/")
 
     assert response.status_code == HTTP_200_OK
-    assert response.json() == {
+    json = response.json()
+    edited_json = (
+        jq.compile(".results[] |= (.organization |= del(.registration_id_list))")
+        .input(json)
+        .first()
+    )
+    assert edited_json == {
         "count": 2,
         "next": None,
         "previous": None,
@@ -155,7 +162,13 @@ def test_api_users_authenticated_list_by_email():
     response = client.get("/api/v1.0/users/?q=ool")
 
     assert response.status_code == HTTP_200_OK
-    assert response.json()["results"] == [
+    json = response.json()
+    edited_json = (
+        jq.compile(".results[] |= (.organization |= del(.registration_id_list))")
+        .input(json)
+        .first()
+    )
+    assert edited_json["results"] == [
         {
             "id": str(frank.id),
             "email": frank.email,
@@ -228,7 +241,13 @@ def test_api_users_authenticated_list_by_name():
     response = client.get("/api/v1.0/users/?q=oole")
 
     assert response.status_code == HTTP_200_OK
-    assert response.json()["results"] == [
+    json = response.json()
+    edited_json = (
+        jq.compile(".results[] |= (.organization |= del(.registration_id_list))")
+        .input(json)
+        .first()
+    )
+    assert edited_json["results"] == [
         {
             "id": str(frank.id),
             "email": frank.email,

--- a/src/backend/core/tests/users/test_api_users_retrieve.py
+++ b/src/backend/core/tests/users/test_api_users_retrieve.py
@@ -61,6 +61,7 @@ def test_api_users_retrieve_me_authenticated():
         "organization": {
             "id": str(user.organization.pk),
             "name": user.organization.name,
+            "registration_id_list": user.organization.registration_id_list,
         },
     }
 

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -639,6 +639,8 @@ class Development(Base):
     # this is a dev credentials for mail provisioning API
     MAIL_PROVISIONING_API_CREDENTIALS = "bGFfcmVnaWU6cGFzc3dvcmQ="
 
+    OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
+
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
         # pylint: disable=invalid-name

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "drf-spectacular-sidecar==2024.12.1",
     "ipdb==0.13.13",
     "ipython==8.31.0",
+    "jq==1.8.0",
     "pyfakefs==5.7.3",
     "pylint-django==2.6.1",
     "pylint==3.3.2",

--- a/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+import { keyCloakSignIn } from './common';
+
+test.beforeEach(async ({ page, browserName }) => {
+  await page.goto('/');
+  await keyCloakSignIn(page, browserName, 'marie');
+});
+
+test.describe('OIDC interop with SIRET', () => {
+  test('it checks the SIRET is displayed in /me endpoint', async ({ page }) => {
+    const header = page.locator('header').first();
+    await expect(header.getByAltText('Marianne Logo')).toBeVisible();
+
+    const response = await page.request.get(
+      'http://localhost:8071/api/v1.0/users/me/',
+    );
+    expect(response.ok()).toBeTruthy();
+    expect(await response.json()).toMatchObject({
+      organization: { registration_id_list: ['21580304000017'] },
+    });
+  });
+});

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -26,6 +26,7 @@ backend:
     OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token
     OIDC_OP_USER_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/userinfo
     OIDC_OP_LOGOUT_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/session/end
+    OIDC_ORGANIZATION_REGISTRATION_ID_FIELD: "siret"
     OIDC_RP_CLIENT_ID:
       secretKeyRef:
         name: backend


### PR DESCRIPTION
## Purpose

Improve developer experience by making local dev resemble production conditions more closely.

## Proposal

We can now find organization data as provided by ProConnect in `user_info`, specifically SIRET.

## Also in this PR:

### Add `OIDC_ORGANIZATION_REGISTRATION_ID_FIELD` to local dev settings

Otherwise local development would be blind to registration ID fields (e.g. SIRET)… and these will become more important as we start dealing with a variety of organizations both private and public (such as French communes).

### Expose organization registration ID field (e.g. SIRET) in /users/me endpoint

This is mostly to have a convenient way of testing the delivered feature, via an API-oriented E2E test. This isn't entirely satisfactory: as this is a very important feature, we should be able to unit test it. The E2E test depends on technical details such as the fact that we use Keycloak to simulate the ProConnect flow.

### Add `jq` to Python dev dependencies, so we can perform "surgery" on JSON responses

This is necessary for several backend tests that query the `/users` endpoint. These tests retrieve a JSON object and test for strict equality. But strict equality is much more stringent than what these tests intend to assert ! We only want to assert that queries for a given set of users will return all the users, and only those users, that the query designates. We are not interested in, for instance, the exact registration IDs of each of the users' organizations. (It is a matter for a more focused unit test to test, for instance, that the User serializer returns certain Organization fields.)

Also, if we tested against the actual, exact registration IDs of organizations, then our tests would become dependent on the order in which they are run, which is unacceptable.