### PR TITLE
✅(e2e) sync keycloak users w/ backend users

### DIFF
--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -101,211 +101,211 @@
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-member",
-      "email": "jean.team-member@example.com",
+      "username": "e2e.team-member",
+      "email": "e2e.team-member@example.com",
       "firstName": "E2E",
       "lastName": "Group Member",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-member"
+          "value": "password-e2e.team-member"
         }
       ],
       "realmRoles": ["user"]
     },
         {
-      "username": "jean.team-administrator",
-      "email": "jean.team-administrator@example.com",
+      "username": "e2e.team-administrator",
+      "email": "e2e.team-administrator@example.com",
       "firstName": "E2E",
       "lastName": "Group Administrator",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-administrator"
+          "value": "password-e2e.team-administrator"
         }
       ],
       "realmRoles": ["user"]
     },
         {
-      "username": "jean.team-owner",
-      "email": "jean.team-owner@example.com",
+      "username": "e2e.team-owner",
+      "email": "e2e.team-owner@example.com",
       "firstName": "E2E",
       "lastName": "Group Owner",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-owner"
+          "value": "password-e2e.team-owner"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.mail-member",
-      "email": "jean.mail-member@example.com",
+      "username": "e2e.mail-member",
+      "email": "e2e.mail-member@example.com",
       "firstName": "E2E",
       "lastName": "Mailbox Member",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.mail-member"
+          "value": "password-e2e.mail-member"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.mail-administrator",
-      "email": "jean.mail-administrator@example.com",
+      "username": "e2e.mail-administrator",
+      "email": "e2e.mail-administrator@example.com",
       "firstName": "E2E",
       "lastName": "Mailbox Administrator",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.mail-administrator"
+          "value": "password-e2e.mail-administrator"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.mail-owner",
-      "email": "jean.mail-owner@example.com",
+      "username": "e2e.mail-owner",
+      "email": "e2e.mail-owner@example.com",
       "firstName": "E2E",
       "lastName": "Mailbox Owner",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.mail-owner"
+          "value": "password-e2e.mail-owner"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-member-mail-member",
-      "email": "jean.team-member-mail-member@example.com",
+      "username": "e2e.team-member-mail-member",
+      "email": "e2e.team-member-mail-member@example.com",
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Member",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-member-mail-member"
+          "value": "password-e2e.team-member-mail-member"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-member-mail-administrator",
-      "email": "jean.team-member-mail-administrator@example.com",
+      "username": "e2e.team-member-mail-administrator",
+      "email": "e2e.team-member-mail-administrator@example.com",
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Administrator",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-member-mail-administrator"
+          "value": "password-e2e.team-member-mail-administrator"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-member-mail-owner",
-      "email": "jean.team-member-mail-owner@example.com",
+      "username": "e2e.team-member-mail-owner",
+      "email": "e2e.team-member-mail-owner@example.com",
       "firstName": "E2E",
       "lastName": "Group Member Mailbox Owner",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-member-mail-owner"
+          "value": "password-e2e.team-member-mail-owner"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-administrator-mail-member",
-      "email": "jean.team-administrator-mail-member@example.com",
+      "username": "e2e.team-administrator-mail-member",
+      "email": "e2e.team-administrator-mail-member@example.com",
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Member",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-administrator-mail-member"
+          "value": "password-e2e.team-administrator-mail-member"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-administrator-mail-administrator",
-      "email": "jean.team-administrator-mail-administrator@example.com",
+      "username": "e2e.team-administrator-mail-administrator",
+      "email": "e2e.team-administrator-mail-administrator@example.com",
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Administrator",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-administrator-mail-administrator"
+          "value": "password-e2e.team-administrator-mail-administrator"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-administrator-mail-owner",
-      "email": "jean.team-administrator-mail-owner@example.com",
+      "username": "e2e.team-administrator-mail-owner",
+      "email": "e2e.team-administrator-mail-owner@example.com",
       "firstName": "E2E",
       "lastName": "Group Administrator Mailbox Owner",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-administrator-mail-owner"
+          "value": "password-e2e.team-administrator-mail-owner"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-owner-mail-member",
-      "email": "jean.team-owner-mail-member@example.com",
+      "username": "e2e.team-owner-mail-member",
+      "email": "e2e.team-owner-mail-member@example.com",
       "firstName": "E2E",
       "lastName": "Group Owner Mailbox Member",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-owner-mail-member"
+          "value": "password-e2e.team-owner-mail-member"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-owner-mail-administrator",
-      "email": "jean.team-owner-mail-administrator@example.com",
+      "username": "e2e.team-owner-mail-administrator",
+      "email": "e2e.team-owner-mail-administrator@example.com",
       "firstName": "E2E",
       "lastName": "Group Owner Mailbox Administrator",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-owner-mail-administrator"
+          "value": "password-e2e.team-owner-mail-administrator"
         }
       ],
       "realmRoles": ["user"]
     },
     {
-      "username": "jean.team-owner-mail-owner",
-      "email": "jean.team-owner-mail-owner@example.com",
+      "username": "e2e.team-owner-mail-owner",
+      "email": "e2e.team-owner-mail-owner@example.com",
       "firstName": "E2E",
       "lastName": "Mailbox Owner",
       "enabled": true,
       "credentials": [
         {
           "type": "password",
-          "value": "password-e2e-jean.team-owner-mail-owner"
+          "value": "password-e2e.team-owner-mail-owner"
         }
       ],
       "realmRoles": ["user"]

--- a/docs/testsE2E.md
+++ b/docs/testsE2E.md
@@ -19,18 +19,18 @@ A new browser window will open and you will be able to run the tests.
 ## Available accounts
 
 The `make demo` command creates the following accounts:
- - `jean.team-<role>@example.com` where `<role>` is one of `administrator`, `member`, `owner`:
+ - `e2e.team-<role>@example.com` where `<role>` is one of `administrator`, `member`, `owner`:
     this account only belong to a team with the specified role.
- - `jean.mail-<role>@example.com` where `<role>` is one of `administrator`, `member`, `owner`:
+ - `e2e.mail-<role>@example.com` where `<role>` is one of `administrator`, `member`, `owner`:
     this account only have a mailbox with the specified role access.
- - `jean.team-<team_role>-mail-<domain_role>@example.com` with a combination of roles as for the
+ - `e2e.team-<team_role>-mail-<domain_role>@example.com` with a combination of roles as for the
     previous accounts.
 
-For each account, the password is `password-e2e-<username>`, for instance `password-e2e-jean.team-member`.
+For each account, the password is `password-e2e.<role>`, for instance `password-e2e.team-member`.
 
 In the E2E tests you can use these accounts to benefit from there accesses, 
 using the `keyCloakSignIn(page, browserName, <account_name>)`. The account name is the 
-username without the prefix `jean.`.
+username without the prefix `e2e.`.
 
 ``` typescript jsx
 await keyCloakSignIn(page, browserName, 'mail-owner');

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -233,8 +233,8 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
         for role in models.RoleChoices.values:
             team_user = models.User(
                 sub=uuid4(),
-                email=f"jean.team-{role}@example.com",
-                name=f"Jean Group {role.capitalize()}",
+                email=f"e2e.team-{role}@example.com",
+                name=f"E2E Group {role.capitalize()}",
                 password="!",
                 is_superuser=False,
                 is_active=True,
@@ -249,8 +249,8 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
         for role in models.RoleChoices.values:
             user_with_mail = models.User(
                 sub=uuid4(),
-                email=f"jean.mail-{role}@example.com",
-                name=f"Jean Mail {role.capitalize()}",
+                email=f"e2e.mail-{role}@example.com",
+                name=f"E2E Mail {role.capitalize()}",
                 password="!",
                 is_superuser=False,
                 is_active=True,
@@ -270,8 +270,8 @@ def create_demo(stdout):  # pylint: disable=too-many-locals
             for domain_role in models.RoleChoices.values:
                 team_mail_user = models.User(
                     sub=uuid4(),
-                    email=f"jean.team-{team_role}-mail-{domain_role}@example.com",
-                    name=f"Jean Group {team_role.capitalize()} Mail {domain_role.capitalize()}",
+                    email=f"e2e.team-{team_role}-mail-{domain_role}@example.com",
+                    name=f"E2E Group {team_role.capitalize()} Mail {domain_role.capitalize()}",
                     password="!",
                     is_superuser=False,
                     is_active=True,

--- a/src/frontend/apps/e2e/__tests__/app-desk/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/common.ts
@@ -12,10 +12,10 @@ export const keyCloakSignIn = async (
   });
 
   const username = accountName
-    ? `jean.${accountName}`
+    ? `e2e.${accountName}`
     : `user-e2e-${browserName}`;
   const password = accountName
-    ? `password-e2e-jean.${accountName}`
+    ? `password-e2e.${accountName}`
     : `password-e2e-${browserName}`;
 
   if (title?.includes('Sign in to your account')) {

--- a/src/frontend/apps/e2e/__tests__/app-desk/member-delete.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/member-delete.spec.ts
@@ -17,7 +17,7 @@ test.describe('Members Delete', () => {
     const table = page.getByLabel('List members card').getByRole('table');
 
     const cells = table.getByRole('row').nth(1).getByRole('cell');
-    await expect(cells.nth(1)).toHaveText('Jean Group Member');
+    await expect(cells.nth(1)).toHaveText('E2E Group Member');
     await cells.nth(4).getByLabel('Member options').click();
     await page.getByLabel('Open the modal to delete this member').click();
 
@@ -137,7 +137,7 @@ test.describe('Members Delete', () => {
     await createTeam(page, 'member-delete-6', browserName, 1);
 
     // To not be the only owner
-    await addNewMember(page, 0, 'Owner', 'Jean');
+    await addNewMember(page, 0, 'Owner', 'E2E');
 
     const username = await addNewMember(page, 0, 'Administration', 'Monique');
 


### PR DESCRIPTION
## Purpose

The user full name was not the same, it would induce flaky test, while the user name is updated at user login from the KC data.

## Proposal

Use `E2E` as first name everywhere.

- [x] Update KC data
- [x] Update `create_demo` data
- [x] Update e2e tests
