### PR TITLE
Fetch and display commune name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(anct) fetch and display organization names of communes #583
 - ✨(frontend) display email if no username #562
 - 🧑‍💻(oidc) add ability to pull registration ID (e.g. SIRET) from OIDC #577
 

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -62,7 +62,7 @@
       "username": "e2e.marie",
       "email": "marie.varzy@gmail.com",
       "firstName": "Marie",
-      "lastName": "Devarzy",
+      "lastName": "Delamairie",
       "enabled": true,
       "attributes": {
           "siret": "21580304000017"

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -641,6 +641,8 @@ class Development(Base):
 
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
 
+    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
+
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
         # pylint: disable=invalid-name
@@ -685,6 +687,10 @@ class Test(Base):
 
     # this is a dev credentials for mail provisioning API
     MAIL_PROVISIONING_API_CREDENTIALS = "bGFfcmVnaWU6cGFzc3dvcmQ="
+
+    OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
+
+    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
 
     ORGANIZATION_REGISTRATION_ID_VALIDATORS = [
         {

--- a/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
+++ b/src/backend/plugins/tests/organizations/test_name_from_siret_organization_plugin.py
@@ -6,6 +6,8 @@ import responses
 from core.models import Organization
 from core.plugins.loader import get_organization_plugins
 
+from plugins.organizations import NameFromSiretOrganizationPlugin
+
 pytestmark = pytest.mark.django_db
 
 
@@ -135,3 +137,34 @@ def test_organization_plugins_run_after_create_name_already_set(
         name="Magic WOW", registration_id_list=["12345678901234"]
     )
     assert organization.name == "Magic WOW"
+
+
+def test_extract_name_from_org_data_when_commune(
+    organization_plugins_settings,
+):
+    """Test the name is extracted correctly for a French commune."""
+    data = {
+        "results": [
+            {
+                "nom_complet": "COMMUNE DE VARZY",
+                "nom_raison_sociale": "COMMUNE DE VARZY",
+                "siege": {
+                    "libelle_commune": "VARZY",
+                    "liste_enseignes": ["MAIRIE"],
+                    "siret": "21580304000017",
+                },
+                "nature_juridique": "7210",
+                "matching_etablissements": [
+                    {
+                        "siret": "21580304000017",
+                        "libelle_commune": "VARZY",
+                        "liste_enseignes": ["MAIRIE"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    plugin = NameFromSiretOrganizationPlugin()
+    name = plugin.get_organization_name_from_results(data, "21580304000017")
+    assert name == "Varzy"

--- a/src/frontend/apps/desk/src/core/auth/api/types.ts
+++ b/src/frontend/apps/desk/src/core/auth/api/types.ts
@@ -9,11 +9,18 @@ export interface User {
   id: string;
   email: string;
   name?: string;
+  organization?: Organization;
   abilities?: {
     mailboxes: UserAbilities;
     contacts: UserAbilities;
     teams: UserAbilities;
   };
+}
+
+export interface Organization {
+  id: string;
+  name: string;
+  registration_id_list: [string];
 }
 
 export type UserAbilities = {

--- a/src/frontend/apps/desk/src/features/header/AccountDropdown.tsx
+++ b/src/frontend/apps/desk/src/features/header/AccountDropdown.tsx
@@ -14,7 +14,12 @@ export const AccountDropdown = () => {
     <DropButton
       button={
         <Box $flex $direction="row" $align="center">
-          <Text $theme="primary">{userName}</Text>
+          <Box $flex $direction="column" $align="left">
+            <Text $theme="primary">{userName}</Text>
+            {userData?.organization?.registration_id_list?.at(0) && (
+              <Text $theme="primary">{userData?.organization?.name}</Text>
+            )}
+          </Box>
           <Text className="material-icons" $theme="primary" aria-hidden="true">
             arrow_drop_down
           </Text>

--- a/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/siret.spec.ts
@@ -9,9 +9,6 @@ test.beforeEach(async ({ page, browserName }) => {
 
 test.describe('OIDC interop with SIRET', () => {
   test('it checks the SIRET is displayed in /me endpoint', async ({ page }) => {
-    const header = page.locator('header').first();
-    await expect(header.getByAltText('Marianne Logo')).toBeVisible();
-
     const response = await page.request.get(
       'http://localhost:8071/api/v1.0/users/me/',
     );
@@ -19,5 +16,18 @@ test.describe('OIDC interop with SIRET', () => {
     expect(await response.json()).toMatchObject({
       organization: { registration_id_list: ['21580304000017'] },
     });
+  });
+});
+
+test.describe('When a commune, display commune name below user name', () => {
+  test('it checks the name is added below the user name', async ({ page }) => {
+    const header = page.locator('header').first();
+    await expect(header.getByAltText('Marianne Logo')).toBeVisible();
+
+    const logout = page.getByRole('button', {
+      name: 'Marie Delamairie',
+    });
+
+    await expect(logout.getByText('Varzy')).toBeVisible();
   });
 });

--- a/src/helm/env.d/preprod/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.desk.yaml.gotmpl
@@ -55,7 +55,7 @@ backend:
     OIDC_RP_SCOPES: "openid email siret"
     OIDC_REDIRECT_ALLOWED_HOSTS: https://desk-preprod.beta.numerique.gouv.fr
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    ORGANIZATION_PLUGINS: "plugins.organizations.NameFromSiretOrganizationPlugin"
+    ORGANIZATION_PLUGINS: ["plugins.organizations.NameFromSiretOrganizationPlugin"]
     ORGANIZATION_REGISTRATION_ID_VALIDATORS: '[{"NAME": "django.core.validators.RegexValidator", "OPTIONS": {"regex": "^[0-9]{14}$"}}]'
     LOGIN_REDIRECT_URL: https://desk-preprod.beta.numerique.gouv.fr
     LOGIN_REDIRECT_URL_FAILURE: https://desk-preprod.beta.numerique.gouv.fr

--- a/src/helm/env.d/production/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/production/values.desk.yaml.gotmpl
@@ -44,7 +44,7 @@ backend:
     OIDC_OP_TOKEN_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/token
     OIDC_OP_USER_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/userinfo
     OIDC_OP_LOGOUT_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/session/end
-    ORGANIZATION_PLUGINS: "plugins.organizations.NameFromSiretOrganizationPlugin"
+    ORGANIZATION_PLUGINS: ["plugins.organizations.NameFromSiretOrganizationPlugin"]
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD: "siret"
     OIDC_RP_CLIENT_ID:
       secretKeyRef:


### PR DESCRIPTION
## Purpose

New users from communes should be able to make sense of what they can do with Régie.

## Proposal

When arriving at Régie from ProConnect, make sure things are set up properly:
- lookup the Commune using the provided SIRET
- ensure the Organization is created with the commune's name

Fixes #610 
