### PR TITLE
🐛(mailbox) fix activate mailbox feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(mailbox) fix activate mailbox feature
 - 🔧(helm) fix the configuration environment #579
 
 ## [1.7.1] - 2024-11-28

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -375,7 +375,12 @@ class DimailAPIClient:
         """Send a request to enable a mailbox to dimail API"""
         response = session.patch(
             f"{self.API_URL}/domains/{mailbox.domain.name}/mailboxes/{mailbox.local_part}",
-            json={"active": "yes"},
+            json={
+                "active": "yes",
+                "givenName": mailbox.first_name,
+                "surName": mailbox.last_name,
+                "displayName": f"{mailbox.first_name} {mailbox.last_name}",
+            },
             headers=self.get_headers(user_sub),
             verify=True,
             timeout=10,


### PR DESCRIPTION
Fix 422 Unprocessable Entity error returned
by dimail because of some missing data sent.
