### PR TITLE
🐛(backend) fix manage roles on domain admin view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) fix manage roles on domain admin view
 - 🐛(mailbox) fix activate mailbox feature
 - 🔧(helm) fix the configuration environment #579
 

--- a/src/backend/mailbox_manager/admin.py
+++ b/src/backend/mailbox_manager/admin.py
@@ -37,7 +37,7 @@ class UserMailDomainAccessInline(admin.TabularInline):
 
     extra = 0
     model = models.MailDomainAccess
-    readonly_fields = ("created_at", "updated_at", "domain", "user")
+    readonly_fields = ("created_at", "updated_at", "domain")
 
 
 @admin.register(models.MailDomain)


### PR DESCRIPTION
Fix creation of new role to manage mail domain on admin interface
