### PR TITLE
✅(e2e) fix flaky test

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -10,7 +10,7 @@ const interceptCommonApiCalls = async (
   arrayMailDomains: MailDomain[],
 ) => {
   const singleMailDomain = arrayMailDomains[0];
-  await page.route('**/api/v1.0/mail-domains/?page=*', async (route) => {
+  await page.route('**/api/v1.0/mail-domains/\?*', async (route) => {
     await route.fulfill({
       json: {
         count: arrayMailDomains.length,


### PR DESCRIPTION
## Purpose

The URL may or may not include the "page" query parameter.

## Proposal

Do not enforce the "page" parameter when mocking the API.