### PR TITLE
🐛(maildomain) fix domain access creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(backend) fix manage roles on domain admin view
+
 ### Added
 
 - ✨(organizations) add siret to name conversion #584

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -245,7 +245,7 @@ class DimailAPIClient:
         except json.decoder.JSONDecodeError:
             error_content = response.content.decode(response.encoding)
 
-        logger.error(
+        logger.exception(
             "[DIMAIL] unexpected error : %s %s", response.status_code, error_content
         )
         raise requests.exceptions.HTTPError(


### PR DESCRIPTION
Lors de la création d'un nouveau domaine, un appel à dimail est réalisé pour créer le user et l'accès coté dimail avant même la création du rôle owner sur le domaine.
Lorsque la création user/allow coté dimail échoue, le rôle owner n'est pas créé de notre coté. Par conséquent le domaine est créé mais invisible sur l'interface de l'utilisateur. 
Il va alors probablement retenter de créer un domaine avec le même nom et là il aura une erreur lui disant qu'il existe déjà.
Pour éviter ça on s'assure de créer le rôle owner de notre coté malgré l'echec dimail, 
on passe le status du domain en failed et on log un message d'erreur.

## TODO

- [x] implementation
- [x] tests
