### PR TITLE
⬆️(dimail) upgrade dimail to 0.0.20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
 
   dimail: 
     entrypoint: /opt/dimail-api/start-dev.sh
-    image: registry.mim-libre.fr/dimail/dimail-api:v0.0.16
+    image: registry.mim-libre.fr/dimail/dimail-api:v0.0.20
     pull_policy: always
     environment:
       DIMAIL_MODE: FAKE


### PR DESCRIPTION
## Purpose

upgrade to 0.0.20 to fix weird anonymous admin behaviour when database not initialized.
Weird behaviour in question : 
Dimail would allow every database change when user table empty. This means that, when forgetting to setup your dimail db, you could create domains, users and only fail after that (by example, for an allows), where you would be rejected because your credentials (used for the first time) would not match any user.
