### PR TITLE
Front pour les dernières évols sur les noms de domains/mailboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(frontend) disable mailbox and allow to create pending mailbox
 - ✨(organizations) add siret to name conversion #584
 - 💄(frontend) redirect home according to abilities #588
 - ✨(maildomain_access) add API endpoint to search users #508

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/api/useUpdateMailboxStatus.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/api/useUpdateMailboxStatus.tsx
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { APIError, errorCauses, fetchAPI } from '@/api';
+
+import { KEY_LIST_MAILBOX } from './useMailboxes';
+
+export interface DisableMailboxParams {
+  mailDomainSlug: string;
+  mailboxId: string;
+  isEnabled: boolean;
+}
+
+export const disableMailbox = async ({
+  mailDomainSlug,
+  mailboxId,
+  isEnabled,
+}: DisableMailboxParams): Promise<void> => {
+  const response = await fetchAPI(
+    `mail-domains/${mailDomainSlug}/mailboxes/${mailboxId}/${
+      isEnabled ? 'enable' : 'disable'
+    }/`,
+    {
+      method: 'POST',
+    },
+  );
+
+  if (!response.ok) {
+    throw new APIError(
+      'Failed to disable the mailbox',
+      await errorCauses(response),
+    );
+  }
+};
+
+export const useUpdateMailboxStatus = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, APIError, DisableMailboxParams>({
+    mutationFn: disableMailbox,
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: [
+          KEY_LIST_MAILBOX,
+          { mailDomainSlug: variables.mailDomainSlug },
+        ],
+      });
+    },
+  });
+};

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/MailDomainsActions.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/MailDomainsActions.tsx
@@ -1,0 +1,115 @@
+import {
+  Button,
+  Modal,
+  ModalSize,
+  VariantType,
+  useModal,
+  useToastProvider,
+} from '@openfun/cunningham-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, DropButton, IconOptions, Text } from '@/components';
+
+import { MailDomain } from '../../domains/types';
+import { useUpdateMailboxStatus } from '../api/useUpdateMailboxStatus';
+import { MailDomainMailbox } from '../types';
+
+interface MailDomainsActionsProps {
+  mailbox: MailDomainMailbox;
+  mailDomain: MailDomain;
+}
+
+export const MailDomainsActions = ({
+  mailDomain,
+  mailbox,
+}: MailDomainsActionsProps) => {
+  const { t } = useTranslation();
+  const [isDropOpen, setIsDropOpen] = useState(false);
+  const isEnabled = mailbox.status === 'enabled';
+  const disableModal = useModal();
+  const { toast } = useToastProvider();
+
+  const { mutate: updateMailboxStatus } = useUpdateMailboxStatus();
+
+  const handleUpdateMailboxStatus = () => {
+    disableModal.close();
+    updateMailboxStatus(
+      {
+        mailDomainSlug: mailDomain.slug,
+        mailboxId: mailbox.id,
+        isEnabled: !isEnabled,
+      },
+      {
+        onError: () =>
+          toast(t('Failed to update mailbox status'), VariantType.ERROR),
+      },
+    );
+  };
+
+  if (mailbox.status === 'pending' || mailbox.status === 'failed') {
+    return null;
+  }
+
+  return (
+    <>
+      <DropButton
+        button={
+          <IconOptions
+            isOpen={isDropOpen}
+            aria-label={t('Open the access options modal')}
+          />
+        }
+        onOpenChange={(isOpen) => setIsDropOpen(isOpen)}
+        isOpen={isDropOpen}
+      >
+        <Box>
+          <Button
+            aria-label={t('Open the modal to update the role of this access')}
+            onClick={() => {
+              setIsDropOpen(false);
+              if (isEnabled) {
+                disableModal.open();
+              } else {
+                handleUpdateMailboxStatus();
+              }
+            }}
+            fullWidth
+            color="primary-text"
+            icon={
+              <span className="material-icons" aria-hidden="true">
+                {isEnabled ? 'lock' : 'lock_open'}
+              </span>
+            }
+          >
+            <Text $theme="primary">
+              {isEnabled ? t('Disable mailbox') : t('Enable mailbox')}
+            </Text>
+          </Button>
+        </Box>
+      </DropButton>
+      <Modal
+        isOpen={disableModal.isOpen}
+        onClose={disableModal.close}
+        title={<Text $size="h3">{t('Disable mailbox')}</Text>}
+        size={ModalSize.MEDIUM}
+        rightActions={
+          <Box $direction="row" $justify="flex-end" $gap="0.5rem">
+            <Button color="secondary" onClick={disableModal.close}>
+              {t('Cancel')}
+            </Button>
+            <Button color="danger" onClick={handleUpdateMailboxStatus}>
+              {t('Disable')}
+            </Button>
+          </Box>
+        }
+      >
+        <Text>
+          {t(
+            'Are you sure you want to disable this mailbox? This action results in the deletion of the calendar, address book, etc.',
+          )}
+        </Text>
+      </Modal>
+    </>
+  );
+};

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/__tests__/MailDomainsContent.test.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/__tests__/MailDomainsContent.test.tsx
@@ -195,10 +195,6 @@ describe('MailDomainsContent', () => {
 
     const statuses = [
       {
-        status: 'pending',
-        regex: /Your domain name is being validated/,
-      },
-      {
         status: 'disabled',
         regex:
           /This domain name is deactivated. No new mailboxes can be created/,

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/types.ts
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/types.ts
@@ -6,4 +6,11 @@ export interface MailDomainMailbox {
   first_name: string;
   last_name: string;
   secondary_email: string;
+  status: MailDomainMailboxStatus;
 }
+
+export type MailDomainMailboxStatus =
+  | 'enabled'
+  | 'disabled'
+  | 'pending'
+  | 'failed';

--- a/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-desk/mail-domain.spec.ts
@@ -375,15 +375,8 @@ test.describe('Mail domain', () => {
         ).toBeVisible();
 
         await expect(
-          page.getByText(
-            'Your domain name is being validated.  ' +
-              'You will not be able to create mailboxes until your domain name has been validated by our team.',
-          ),
-        ).toBeVisible();
-
-        await expect(
           page.getByRole('button', { name: 'Create a mailbox' }),
-        ).toBeDisabled();
+        ).toBeEnabled();
 
         await expect(
           page.getByText('No mail box was created with this mail domain.'),
@@ -700,13 +693,6 @@ test.describe('Mail domain', () => {
 
         await expect(
           page.getByRole('heading', { name: 'domain.fr' }),
-        ).toBeVisible();
-
-        await expect(
-          page.getByText(
-            'Your domain name is being validated.  ' +
-              'You will not be able to create mailboxes until your domain name has been validated by our team.',
-          ),
         ).toBeVisible();
 
         await expect(


### PR DESCRIPTION
Permet de désactiver/réactiver une mailbox avec modal de confirmation pour la désactivation car perte de données coté dimail.
Permet de créer des boites mails en pending pour un domaine non actif encore