### PR TITLE
🧑‍💻(user) fix the `User.language`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🧑‍💻(user) fix the User.language infinite migration #611
+
 ## [1.9.1] - 2024-12-18
 
 ## [1.9.0] - 2024-12-17

--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                 ('sub', models.CharField(help_text='Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ characters only.', max_length=255, unique=True, validators=[django.core.validators.RegexValidator(message='Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/_ characters.', regex='^[\\w.@+-]+\\Z')], verbose_name='sub')),
                 ('email', models.EmailField(blank=True, max_length=254, null=True, verbose_name='email address')),
                 ('name', models.CharField(blank=True, max_length=100, null=True, verbose_name='name')),
-                ('language', models.CharField(choices="(('en-us', 'English'), ('fr-fr', 'French'))", default='en-us', help_text='The language in which the user wants to see the interface.', max_length=10, verbose_name='language')),
+                ('language', models.CharField(choices=settings.LANGUAGES, default='en-us', help_text='The language in which the user wants to see the interface.', max_length=10, verbose_name='language')),
                 ('timezone', timezone_field.fields.TimeZoneField(choices_display='WITH_GMT_OFFSET', default='UTC', help_text='The timezone in which the user wants to see times.', use_pytz=False)),
                 ('is_device', models.BooleanField(default=False, help_text='Whether the user is a device or a real user.', verbose_name='device')),
                 ('is_staff', models.BooleanField(default=False, help_text='Whether the user can log into this admin site.', verbose_name='staff status')),

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -21,7 +21,6 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import override
 
@@ -441,7 +440,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
     name = models.CharField(_("name"), max_length=100, null=True, blank=True)
     language = models.CharField(
         max_length=10,
-        choices=lazy(lambda: settings.LANGUAGES, tuple)(),
+        choices=settings.LANGUAGES,
         default=settings.LANGUAGE_CODE,
         verbose_name=_("language"),
         help_text=_("The language in which the user wants to see the interface."),


### PR DESCRIPTION
## Purpose

The use of a lazy function here make the Django migration detector to generate a migration every time we run `makemigrations`. 

## Proposal

This is not mandatory to have a lazy here as the settings are loaded once at runtime beginning.
As the choices makes noop migrations, we directly use the setting in the initial migration.

- [x] remove the lazy function
- [x] update the initial migration
