### PR TITLE
🐛(dimail) fix mailboxes import from dimail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🐛(dimail) fix mailboxes import from dimail #612
+
 ## [1.9.1] - 2024-12-18
 
 ## [1.9.0] - 2024-12-17

--- a/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
+++ b/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
@@ -124,6 +124,16 @@ def test_dimail_synchronization__synchronize_mailboxes(caplog):
             "surName": "Vang",
             "displayName": "Jean Vang",
         }
+        import json
+        null = None
+        mailbox_null_names = {
+            "type": "mailbox",
+            "status": "broken",
+            "email": f"null@{domain.name}",
+            "givenName": null,
+            "surName": null,
+            "displayName": null,
+        }
 
         rsps.add(
             rsps.GET,
@@ -132,9 +142,10 @@ def test_dimail_synchronization__synchronize_mailboxes(caplog):
                 [
                     mailbox_valid,
                     mailbox_valid_additional_senders,
-                    mailbox_with_wrong_domain,
-                    mailbox_invalid_domain,
-                    mailbox_with_invalid_local_part,
+                    # mailbox_with_wrong_domain,
+                    # mailbox_invalid_domain,
+                    # mailbox_with_invalid_local_part,
+                    mailbox_null_names,
                 ]
             ).replace("'", '"'),
             status=status.HTTP_200_OK,

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -311,7 +311,14 @@ class DimailAPIClient:
         if response.status_code != status.HTTP_200_OK:
             return self.raise_exception_for_unexpected_response(response)
 
-        dimail_mailboxes = response.json()
+        try:
+            import pdb; pdb.set_trace()
+        except requests.exceptions.JSONDecodeError as err:
+            logger.error(
+                "Import failed because of wrong json format: %s",
+                err,
+            )
+            return []
 
         people_mailboxes = models.Mailbox.objects.filter(domain=domain)
         imported_mailboxes = []


### PR DESCRIPTION
## Purpose

I tried to import existing mailboxes from dimail for domain and raised an error because the response had an unexpected format.

update dimail response when requesting get_mailboxes

EDIT 06/01 : It seems to be fixed. I'm confused. I'll keep this PR to add tests regarding a new field in dimail's response : "additional Senders".

## Proposal

Description...

- [] item 1...
- [] item 2...

I'm getting bolossed by json. For an error that does not exist in prod, but I simply can't reproduce the behaviour in responsesMock. Send help, please.
