### PR TITLE
🐛(backend) fix dimail call despite mailbox creation failure on our side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) fix dimail call despite mailbox creation failure on our side
 - 🧑‍💻(user) fix the User.language infinite migration #611
 
 ## [1.9.1] - 2024-12-18


### PR DESCRIPTION
When we try to create a duplicate email, a request to dimail is sent despite a reject on our side.
To solve this issue, we call mailbox creation first to benefit from validation of our Django model.

Mailbox creation try was called too late after dimail call. So in attempt to create a duplicated email a request to dimail was sent despite a failure in our side.
