### PR TITLE
Automate domain creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to
 
 ### Added
 
+- ✨(anct) auto create domains #622
 - ✨(teams) add Team dependencies #560
 - ✨(organization) add admin action for plugin #640
 - ✨(anct) fetch and display organization names of communes #583
 - ✨(frontend) display email if no username #562
+- ✨(anct) fetch and display organization names of communes #583
 - 🧑‍💻(oidc) add ability to pull registration ID (e.g. SIRET) from OIDC #577
 
 ### Fixed

--- a/src/backend/core/tests/resource_server_api/teams/test_list.py
+++ b/src/backend/core/tests/resource_server_api/teams/test_list.py
@@ -192,9 +192,9 @@ def test_api_teams_order_param(client, force_login_via_resource_server):
     response_data = response.json()
     response_team_ids = [team["id"] for team in response_data["results"]]
 
-    assert (
-        response_team_ids == team_ids
-    ), "created_at values are not sorted from oldest to newest"
+    assert response_team_ids == team_ids, (
+        "created_at values are not sorted from oldest to newest"
+    )
 
 
 def test_api_teams_list_with_parent_teams(client, force_login_via_resource_server):

--- a/src/backend/core/tests/teams/test_core_api_teams_list.py
+++ b/src/backend/core/tests/teams/test_core_api_teams_list.py
@@ -95,9 +95,9 @@ def test_api_teams_order():
     response_team_ids = [team["id"] for team in response_data]
 
     team_ids.reverse()
-    assert (
-        response_team_ids == team_ids
-    ), "created_at values are not sorted from newest to oldest"
+    assert response_team_ids == team_ids, (
+        "created_at values are not sorted from newest to oldest"
+    )
 
 
 def test_api_teams_order_param():
@@ -122,9 +122,9 @@ def test_api_teams_order_param():
     response_data = response.json()
     response_team_ids = [team["id"] for team in response_data]
 
-    assert (
-        response_team_ids == team_ids
-    ), "created_at values are not sorted from oldest to newest"
+    assert response_team_ids == team_ids, (
+        "created_at values are not sorted from oldest to newest"
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/backend/mailbox_manager/tests/commands/test_dimail_setup_db.py
+++ b/src/backend/mailbox_manager/tests/commands/test_dimail_setup_db.py
@@ -119,10 +119,7 @@ def test_commands_setup_dimail_db(settings):
 
     assert (
         f"{DIMAIL_URL}/users/",
-        (
-            b'{"name": "sub.toto.123", "password": "no", "is_admin": false, '
-            b'"perms": []}'
-        ),
+        (b'{"name": "sub.toto.123", "password": "no", "is_admin": false, "perms": []}'),
     ) in dimail_calls
 
     assert (

--- a/src/backend/people/settings.py
+++ b/src/backend/people/settings.py
@@ -466,6 +466,18 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # DNS PROVISIONING API
+    DNS_PROVISIONING_API_CREDENTIALS = values.Value(
+        default=None,
+        environ_name="DNS_PROVISIONING_API_CREDENTIALS",
+        environ_prefix=None,
+    )
+    DNS_PROVISIONING_API_PROJECT_ID = values.Value(
+        default=None,
+        environ_name="DNS_PROVISIONING_API_PROJECT_ID",
+        environ_prefix=None,
+    )
+
     # Organizations
     ORGANIZATION_REGISTRATION_ID_VALIDATORS = json.loads(
         values.Value(
@@ -642,7 +654,7 @@ class Development(Base):
 
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
 
-    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
+    ORGANIZATION_PLUGINS = ["plugins.organizations.CommuneCreation"]
 
     def __init__(self):
         """In dev, force installs needed for Swagger API."""
@@ -691,7 +703,7 @@ class Test(Base):
 
     OIDC_ORGANIZATION_REGISTRATION_ID_FIELD = "siret"
 
-    ORGANIZATION_PLUGINS = ["plugins.organizations.NameFromSiretOrganizationPlugin"]
+    ORGANIZATION_PLUGINS = ["plugins.organizations.CommuneCreation"]
 
     ORGANIZATION_REGISTRATION_ID_VALIDATORS = [
         {

--- a/src/backend/plugins/organizations.py
+++ b/src/backend/plugins/organizations.py
@@ -17,6 +17,15 @@ class ApiCall:
     url : str = ""
     params: dict = {}
     headers : dict = {}
+    response = None
+
+    def execute(self):
+        if (self.method == "POST"):
+            self.response = requests.request(
+                method=self.method,
+                url=f"https://{self.host}/{self.url}",
+                json=self.params,
+                headers=self.headers)
 
 class CommuneCreation(BaseOrganizationPlugin):
     """

--- a/src/backend/plugins/tests/organizations/test_commune_creation.py
+++ b/src/backend/plugins/tests/organizations/test_commune_creation.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from core.models import Organization
 from core.plugins.loader import get_organization_plugins
 
-from plugins.organizations import CommuneCreation
+from plugins.organizations import CommuneCreation, ApiCall
 
 pytestmark = pytest.mark.django_db
 
@@ -170,6 +170,25 @@ def test_extract_name_from_org_data_when_commune(
     plugin = CommuneCreation()
     name = plugin.get_organization_name_from_results(data, "21580304000017")
     assert name == "Varzy"
+
+def test_api_call_execution():
+    task = ApiCall()
+    task.method = "POST"
+    task.host = "some_host"
+    task.url = "some_url"
+    task.params = {"some_key":"some_value"}
+    task.headers = {"Some-Header": "Some-Header-Value"}
+    
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            rsps.POST,
+            url="https://some_host/some_url",
+            body='{"some_key": "some_value"}',
+            content_type="application/json",
+            headers={"Some-Header": "Some-Header-Value"}
+        )
+
+        task.execute()
 
 def test_tasks_on_commune_creation_include_zone_creation():
     plugin = CommuneCreation()

--- a/src/helm/env.d/dev/values.desk.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.desk.yaml.gotmpl
@@ -50,7 +50,7 @@ backend:
     OIDC_RP_SCOPES: "openid email siret"
     OIDC_REDIRECT_ALLOWED_HOSTS: https://desk.127.0.0.1.nip.io
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    ORGANIZATION_PLUGINS: "plugins.organizations.NameFromSiretOrganizationPlugin"
+    ORGANIZATION_PLUGINS: "plugins.organizations.CommuneCreation"
     ORGANIZATION_REGISTRATION_ID_VALIDATORS: '[{"NAME": "django.core.validators.RegexValidator", "OPTIONS": {"regex": "^[0-9]{14}$"}}]'
     LOGIN_REDIRECT_URL: https://desk.127.0.0.1.nip.io
     LOGIN_REDIRECT_URL_FAILURE: https://desk.127.0.0.1.nip.io


### PR DESCRIPTION
## Purpose

Completing #583, ensure users from communes can do something meaningful upon onboarding: create a default domain for them, so that they can create mailboxes

## Proposal

- Introduce ApiCall object, to avoid mocking and anticipating task queuing
- Call Scaleway API upon organization creation to provision subzone and email-related DNS entries
