### PR TITLE
🐛(tests) fix flaky back-end test

### DIFF
--- a/src/backend/core/tests/contacts/test_core_api_contacts_list.py
+++ b/src/backend/core/tests/contacts/test_core_api_contacts_list.py
@@ -100,7 +100,7 @@ def test_api_contacts_list_authenticated_by_full_name():
     Authenticated users should be able to search users with a case insensitive and
     partial query on the full name.
     """
-    user = factories.UserFactory()
+    user = factories.UserFactory(name="Prudence Crandall")
 
     dave = factories.BaseContactFactory(full_name="David Bowman")
     nicole = factories.BaseContactFactory(full_name="Nicole Foole")


### PR DESCRIPTION
## Purpose

Fixed a test that would sometimes fail because of randomly assigned auth user name being too close to tested names (assert would then find 2 results instead of 1). Setting the name of auth user should fix the issue permanently.

## Proposal

Description...

- [x] Setting the name of auth
