### PR TITLE
🧑‍💻(admin) add read-only fields to mailbox admin

### DIFF
--- a/src/backend/mailbox_manager/admin.py
+++ b/src/backend/mailbox_manager/admin.py
@@ -108,9 +108,10 @@ class MailDomainAdmin(admin.ModelAdmin):
 class MailboxAdmin(admin.ModelAdmin):
     """Admin for mailbox model."""
 
-    list_display = ("__str__", "domain", "status")
+    list_display = ("__str__", "domain", "status", "updated_at")
     list_filter = ("status",)
     search_fields = ("local_part", "domain__name")
+    readonly_fields = ["updated_at", "local_part", "domain"]
 
 
 @admin.register(models.MailDomainAccess)


### PR DESCRIPTION
## Purpose

mark local_part and domain as read-only fields in admin, in order to prevent mistakes/temptation. For now, if an local part needs modification, you can simply delete/recreate the email you want. Changing the domain is a bigger operation that cannot be settled simply by changing it Django db.


## Proposal

Description...

- [] item 1...
- [] item 2...
