### PR TITLE
🐛(frontend) fix disable mailbox button display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) fix disable mailbox button display #631
 - 🐛(backend) fix dimail call despite mailbox creation failure on our side
 - 🧑‍💻(user) fix the User.language infinite migration #611
 

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/MailDomainsActions.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/MailDomainsActions.tsx
@@ -47,7 +47,11 @@ export const MailDomainsActions = ({
     );
   };
 
-  if (mailbox.status === 'pending' || mailbox.status === 'failed') {
+  if (
+    mailbox.status === 'pending' ||
+    mailbox.status === 'failed' ||
+    mailDomain.abilities.post === false
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Do not display disable/enable mailbox button
for viewers.
Only owner and admin can manage mailbox and use
this button.

fix #631 