### PR TITLE
✨(organization) add admin action for plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(organization) add admin action for plugin #640
 - ✨(anct) fetch and display organization names of communes #583
 - ✨(frontend) display email if no username #562
 - 🧑‍💻(oidc) add ability to pull registration ID (e.g. SIRET) from OIDC #577


### PR DESCRIPTION
## Purpose

This allows admin user to run the post creation plugins from the organization list.


## Proposal

- [x] add action to the admin to run all the plugins `run_after_create`
