### PR TITLE
🧑‍💻(dimail) remove 'NoneType: None' log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🧑‍💻(dimail) remove 'NoneType: None' log in debug mode
 - 🐛(frontend) fix flaky e2e test #636
 - 🐛(frontend) fix disable mailbox button display #631
 - 🐛(backend) fix dimail call despite mailbox creation failure on our side

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -246,7 +246,10 @@ class DimailAPIClient:
             error_content = response.content.decode(response.encoding)
 
         logger.exception(
-            "[DIMAIL] unexpected error : %s %s", response.status_code, error_content
+            "[DIMAIL] unexpected error : %s %s",
+            response.status_code,
+            error_content,
+            exc_info=False,
         )
         raise requests.exceptions.HTTPError(
             f"Unexpected response from dimail: {response.status_code} "


### PR DESCRIPTION
Fixes "NoneType: None" log appearing in debug mode.
