### PR TITLE
🐛(backend) fix flaky test with search contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) fix flaky test with search contact #605
 - 🐛(backend) fix flaky test with team access #646
 - 🧑‍💻(dimail) remove 'NoneType: None' log in debug mode
 - 🐛(frontend) fix flaky e2e test #636

--- a/src/backend/core/api/client/viewsets.py
+++ b/src/backend/core/api/client/viewsets.py
@@ -25,8 +25,6 @@ from core.api import permissions
 from core.api.client import serializers
 from core.utils.raw_sql import gen_sql_filter_json_array
 
-SIMILARITY_THRESHOLD = 0.04
-
 
 class NestedGenericViewSet(viewsets.GenericViewSet):
     """

--- a/src/backend/core/tests/contacts/test_core_api_contacts_list.py
+++ b/src/backend/core/tests/contacts/test_core_api_contacts_list.py
@@ -102,10 +102,10 @@ def test_api_contacts_list_authenticated_by_full_name():
     """
     user = factories.UserFactory(name="Prudence Crandall")
 
-    dave = factories.BaseContactFactory(full_name="David Bowman")
-    nicole = factories.BaseContactFactory(full_name="Nicole Foole")
-    frank = factories.BaseContactFactory(full_name="Frank Poole")
-    factories.BaseContactFactory(full_name="Heywood Floyd")
+    dave = factories.BaseContactFactory(full_name="David Bowman", data={})
+    nicole = factories.BaseContactFactory(full_name="Nicole Foole", data={})
+    frank = factories.BaseContactFactory(full_name="Frank Poole", data={})
+    factories.BaseContactFactory(full_name="Heywood Floyd", data={})
 
     # Full query should work
     client = APIClient()


### PR DESCRIPTION
Sometimes emails generated by faker in data field match search. So it's necessary to create contacts with empty data field.
closes #605
