### PR TITLE
🐛(dimail) fix imported mailboxes should be enabled instead of pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(dimail) fix imported mailboxes should be enabled instead of pending #659 
 - ⚡️(api) add missing cache for stats endpoint
 
 ## [1.10.0] - 2025-01-21

--- a/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
+++ b/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
@@ -156,6 +156,7 @@ def test_dimail_synchronization__synchronize_mailboxes(mock_warning):
 
         mailbox = models.Mailbox.objects.get()
         assert mailbox.local_part == "oxadmin"
+        assert mailbox.status == enums.MailboxStatusChoices.ENABLED
         assert imported_mailboxes == [mailbox_valid["email"]]
 
 

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -337,10 +337,10 @@ class DimailAPIClient:
                             last_name=dimail_mailbox["surName"],
                             local_part=address.username,
                             domain=domain,
-                            secondary_email=dimail_mailbox[
-                                "email"
-                            ],  # secondary email is mandatory. Unfortunately, dimail doesn't
+                            secondary_email=dimail_mailbox["email"],
+                            # secondary email is mandatory. Unfortunately, dimail doesn't
                             # store any. We temporarily give current email as secondary email.
+                            status=enums.MailboxStatusChoices.ENABLED,
                         )
                         imported_mailboxes.append(str(mailbox))
                     else:


### PR DESCRIPTION
## Purpose

Importing mailboxes creates pending mailboxes ... but these mailboxes are already active and, for most, functional. We thus mark them as "enabled".

## Proposal

Description...

- [x] fixed related test
- [x] set imported mailboxes' statuses to "enabled"
- [ ] for future PR : dimail provides a "status" field that can be either "ok" or "broken". our mailboxes could depend on this status but it's currently not entirely reliable (many "broken" mailboxes actually are functioning).
