### PR TITLE
⬆️(backend) bump Django to 5.2.6

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "django-timezone-field>=5.1",
     "django-treebeard==4.7.1",
     "django-zxcvbn-password-validator==1.4.5",
-    "django==5.2.5",
+    "django==5.2.6",
     "djangorestframework==3.16.1",
     "dockerflow==2024.4.2",
     "drf_spectacular==0.28.0",


### PR DESCRIPTION
## Purpose

Bump Django version to 5.2.6, fixing CVE-2025-57833. See https://www.djangoproject.com/weblog/2025/sep/03/security-releases/
