### PR TITLE
⬆️(dependencies) upgrade node to 22

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -10,7 +10,7 @@ jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
     with:
-      node_version: '18.x'
+      node_version: '22.x'
       with-front-dependencies-installation: true
 
   synchronize-with-crowdin:

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -10,7 +10,7 @@ jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
     with:
-      node_version: '18.x'
+      node_version: '22.x'
       with-front-dependencies-installation: true
       with-build_mails: true
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         required: false
-        default: '18.x'
+        default: '22.x'
         type: string
       with-front-dependencies-installation:
         type: boolean

--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -13,7 +13,7 @@ jobs:
   dependencies:
     uses: ./.github/workflows/dependencies.yml
     with:
-      node_version: '18.x'
+      node_version: '22.x'
       with-front-dependencies-installation: true
       with-build_mails: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /install && \
 
 
 # ---- mails ----
-FROM node:20 AS mail-builder
+FROM node:22 AS mail-builder
 
 COPY ./src/mail /mail/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     working_dir: /app
 
   node:
-    image: node:18
+    image: node:22
     user: "${DOCKER_USER:-1000}"
     environment:
       HOME: /tmp


### PR DESCRIPTION
## Purpose

node 18 reached end-of-life and is now unsupported. we jump straight to 22 as recommended here
https://nodejs.org/en/blog/announcements/node-18-eol-support
