### PR TITLE
🛂(permissions) return 404 to users with no access to domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🛂(permissions) return 404 to users with no access to domain #985 
 - ✨(aliases) can create, list and delete aliases #974
 
 ## [1.20.0] - 2025-10-22

--- a/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_create.py
+++ b/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_create.py
@@ -31,8 +31,8 @@ def test_api_aliases_create__anonymous():
     assert not models.Alias.objects.exists()
 
 
-def test_api_aliases_create__no_access_forbidden():
-    """User authenticated but not having domain permission should not create aliases."""
+def test_api_aliases_create__no_access_forbidden_not_found():
+    """Unrelated user not having domain permission should not create aliases."""
     domain = factories.MailDomainEnabledFactory()
 
     client = APIClient()
@@ -41,7 +41,7 @@ def test_api_aliases_create__no_access_forbidden():
         f"/api/v1.0/mail-domains/{domain.slug}/aliases/",
         {"local_part": "intrusive", "destination": "intrusive@mail.com"},
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert not models.Alias.objects.exists()
 
 

--- a/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_delete.py
+++ b/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_delete.py
@@ -29,7 +29,7 @@ def test_api_aliases_delete__anonymous():
     assert models.Alias.objects.count() == 1
 
 
-def test_api_aliases_delete__no_access_forbidden():
+def test_api_aliases_delete__no_access_forbidden_not_found():
     """
     Authenticated users should not be allowed to delete an alias in a
     mail domain to which they are not related.
@@ -43,7 +43,7 @@ def test_api_aliases_delete__no_access_forbidden():
         f"/api/v1.0/mail-domains/{alias.domain.slug}/aliases/{alias.local_part}/",
     )
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert models.Alias.objects.count() == 1
 
 

--- a/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_list.py
+++ b/src/backend/mailbox_manager/tests/api/aliases/test_api_aliases_list.py
@@ -25,7 +25,7 @@ def test_api_aliases_list__anonymous():
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_api_aliases_list__no_access_forbidden():
+def test_api_aliases_list__no_access_forbidden_not_found():
     """User authenticated but not having domain permission should not list aliases."""
     factories.MailDomainAccessFactory()  # access to another domain
     domain = factories.MailDomainEnabledFactory()
@@ -36,7 +36,7 @@ def test_api_aliases_list__no_access_forbidden():
     response = client.get(
         f"/api/v1.0/mail-domains/{domain.slug}/aliases/",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.parametrize(

--- a/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
+++ b/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
@@ -35,7 +35,7 @@ def test_api_domain_invitations__create__anonymous():
     }
 
 
-def test_api_domain_invitations__create__authenticated_outsider():
+def test_api_domain_invitations__create__no_access_forbidden_not_found():
     """Users should not be permitted to send domain management invitations
     for a domain they don't manage."""
     user = core_factories.UserFactory()
@@ -52,7 +52,7 @@ def test_api_domain_invitations__create__authenticated_outsider():
         invitation_values,
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.parametrize(
@@ -86,7 +86,7 @@ def test_api_domain_invitations__admin_should_create_invites(role):
     assert email.subject == "[La Suite] Vous avez été invité(e) à rejoindre la Régie"
 
 
-def test_api_domain_invitations__viewers_should_not_invite_to_manage_domains():
+def test_api_domain_invitations__no_access_forbidden_not_found():
     """
     Domain viewers should not be able to invite new domain managers.
     """
@@ -110,7 +110,7 @@ def test_api_domain_invitations__viewers_should_not_invite_to_manage_domains():
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {
-        "detail": "You are not allowed to manage invitations for this domain."
+        "detail": "You do not have permission to perform this action."
     }
 
 

--- a/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_retrieve.py
@@ -26,7 +26,7 @@ def test_api_domain_invitations__anonymous_user_should_not_retrieve_invitations(
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_api_domain_invitations__unrelated_user_should_not_retrieve_invitations():
+def test_api_domain_invitations__no_access_forbidden_not_found():
     """
     Authenticated unrelated users should not be able to retrieve invitations.
     """
@@ -40,8 +40,8 @@ def test_api_domain_invitations__unrelated_user_should_not_retrieve_invitations(
         f"/api/v1.0/mail-domains/{invitation.domain.slug}/invitations/",
     )
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["count"] == 0
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "No MailDomain matches the given query."}
 
 
 def test_api_domain_invitations__domain_managers_should_list_invitations():

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
@@ -41,17 +41,14 @@ def test_api_mail_domains__create_name_unique():
     """
     Creating domain should raise an error if already existing name.
     """
-    factories.MailDomainFactory(name="existing_domain.com")
-    user = core_factories.UserFactory()
+    existing_domain = factories.MailDomainFactory()
 
     client = APIClient()
-    client.force_login(user)
+    client.force_login(core_factories.UserFactory())
 
     response = client.post(
         "/api/v1.0/mail-domains/",
-        {
-            "name": "existing_domain.com",
-        },
+        {"name": existing_domain.name},
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_fetch.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_fetch.py
@@ -2,7 +2,6 @@
 Tests for MailDomains API endpoint in People's mailbox manager app. Focus on "fetch" action.
 """
 
-import json
 import re
 
 import pytest
@@ -82,7 +81,7 @@ def test_api_mail_domains__fetch_from_dimail__viewer():
     ],
 )
 @responses.activate
-def test_api_mail_domains__fetch_from_dimail(role):
+def test_api_mail_domains__fetch_from_dimail_admin_successful(role):
     """
     Authenticated users should be allowed to fetch a domain
     from dimail if they are an owner or admin.

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
@@ -69,7 +69,7 @@ def test_api_mail_domains__retrieve_authenticated_unrelated():
 
 
 @responses.activate
-def test_api_mail_domains__retrieve_authenticated_related():
+def test_api_mail_domains__retrieve_authenticated_related_successful():
     """
     Authenticated users should be allowed to retrieve a domain
     to which they have access.

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_create.py
@@ -35,7 +35,7 @@ def test_api_mail_domain__accesses_create_anonymous():
         assert models.MailDomainAccess.objects.exists() is False
 
 
-def test_api_mail_domain__accesses_create_authenticated_unrelated():
+def test_api_mail_domain__accesses_create_no_access_forbidden_not_found():
     """
     Authenticated users should not be allowed to create domain accesses for a domain to
     which they are not related.
@@ -56,14 +56,14 @@ def test_api_mail_domain__accesses_create_authenticated_unrelated():
             format="json",
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {
-            "detail": "You are not allowed to manage accesses for this domain."
+            "detail": "No MailDomain matches the given query.",
         }
         assert not models.MailDomainAccess.objects.filter(user=other_user).exists()
 
 
-def test_api_mail_domain__accesses_create_authenticated_viewer():
+def test_api_mail_domain__accesses_create_viewer_forbidden():
     """Viewer of a mail domain should not be allowed to create mail domain accesses."""
     authenticated_user = core_factories.UserFactory()
     mail_domain = factories.MailDomainFactory(
@@ -85,7 +85,7 @@ def test_api_mail_domain__accesses_create_authenticated_viewer():
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
-            "detail": "You are not allowed to manage accesses for this domain."
+            "detail": "You do not have permission to perform this action.",
         }
 
     assert not models.MailDomainAccess.objects.filter(user=other_user).exists()

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_delete.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_delete.py
@@ -13,7 +13,7 @@ from mailbox_manager import enums, factories, models
 pytestmark = pytest.mark.django_db
 
 
-def test_api_mail_domain__accesses_delete_anonymous():
+def test_api_domain_accesses_delete__anonymous_forbidden():
     """Anonymous users should not be allowed to destroy a mail domain access."""
     access = factories.MailDomainAccessFactory()
 
@@ -25,7 +25,7 @@ def test_api_mail_domain__accesses_delete_anonymous():
     assert models.MailDomainAccess.objects.count() == 1
 
 
-def test_api_mail_domain__accesses_delete_authenticated():
+def test_api_domain_accesses_delete__unrelated_notfound():
     """
     Authenticated users should not be allowed to delete a mail domain access for a
     mail domain to which they are not related.
@@ -39,11 +39,11 @@ def test_api_mail_domain__accesses_delete_authenticated():
         f"/api/v1.0/mail-domains/{access.domain.slug}/accesses/{access.id!s}/",
     )
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert models.MailDomainAccess.objects.count() == 1
 
 
-def test_api_mail_domain__accesses_delete_viewer():
+def test_api_domain_accesses_delete__viewer_forbidden():
     """
     Authenticated users should not be allowed to delete a mail domain access for a
     mail domain in which they are a simple viewer.
@@ -65,7 +65,7 @@ def test_api_mail_domain__accesses_delete_viewer():
     assert models.MailDomainAccess.objects.filter(user=access.user).exists()
 
 
-def test_api_mail_domain__accesses_delete_administrators():
+def test_api_domain_accesses_delete__administrators_successful():
     """
     Administrators of a mail domain should be allowed to delete accesses excepted owner accesses.
     """
@@ -89,7 +89,7 @@ def test_api_mail_domain__accesses_delete_administrators():
         assert models.MailDomainAccess.objects.count() == 1
 
 
-def test_api_mail_domain__accesses_delete_owners():
+def test_api_domain_accesses_delete__owners_successful():
     """
     An owner should be able to delete the mail domain access of another user including
     a owner access.
@@ -114,7 +114,7 @@ def test_api_mail_domain__accesses_delete_owners():
         assert models.MailDomainAccess.objects.count() == 1
 
 
-def test_api_mail_domain__accesses_delete_owners_last_owner():
+def test_api_domain_accesses_delete__last_owner_forbidden():
     """
     It should not be possible to delete the last owner access from a mail domain
     """

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_retrieve.py
@@ -43,7 +43,7 @@ def test_api_mail_domain__accesses_retrieve_authenticated_unrelated():
         f"/api/v1.0/mail-domains/{access.domain.slug}/accesses/{access.id!s}/",
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": "No MailDomainAccess matches the given query."}
+    assert response.json() == {"detail": "No MailDomain matches the given query."}
 
     # Accesses related to another mail_domain should be excluded even if the user is related to it
     for other_access in [
@@ -55,9 +55,7 @@ def test_api_mail_domain__accesses_retrieve_authenticated_unrelated():
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {
-            "detail": "No MailDomainAccess matches the given query."
-        }
+        assert response.json() == {"detail": "No MailDomain matches the given query."}
 
 
 def test_api_mail_domain__accesses_retrieve_authenticated_related():

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_update.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_update.py
@@ -27,7 +27,7 @@ def test_api_mail_domain__accesses_update_anonymous():
     assert access.role == enums.MailDomainRoleChoices.VIEWER
 
 
-def test_api_mail_domain__accesses_update_authenticated_unrelated():
+def test_api_mail_domain__accesses_update_no_access_forbidden_not_found():
     """
     An authenticated user should not be allowed to update a mail domain access
     for a mail_domain to which they are not related.
@@ -42,7 +42,7 @@ def test_api_mail_domain__accesses_update_authenticated_unrelated():
         {"role": enums.MailDomainRoleChoices.ADMIN},
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     access.refresh_from_db()
     assert access.role == enums.MailDomainRoleChoices.VIEWER
 

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domains_accesses_get_available_users.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domains_accesses_get_available_users.py
@@ -30,9 +30,7 @@ def test_api_mail_domain__available_users_anonymous():
 
 
 def test_api_mail_domain__available_users_forbidden():
-    """Authenticated user without accesses on maildomain should not be able to see available
-    users.
-    """
+    """Users with no access should not be able to list available users."""
     authenticated_user = core_factories.UserFactory()
     client = APIClient()
     client.force_login(authenticated_user)
@@ -40,7 +38,7 @@ def test_api_mail_domain__available_users_forbidden():
 
     response = client.get(f"/api/v1.0/mail-domains/{maildomain.slug}/accesses/users/")
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.parametrize(

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_disable.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_disable.py
@@ -26,7 +26,7 @@ def test_api_mailboxes__disable_anonymous_forbidden():
     assert models.Mailbox.objects.get().status == enums.MailboxStatusChoices.ENABLED
 
 
-def test_api_mailboxes__disable_authenticated_failure():
+def test_api_mailboxes__disable_no_access_forbidden_not_found():
     """Authenticated users should not be able to disable mailbox
     without specific role on mail domain."""
     user = core_factories.UserFactory()
@@ -39,7 +39,7 @@ def test_api_mailboxes__disable_authenticated_failure():
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/disable/",
     )
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert models.Mailbox.objects.get().status == enums.MailboxStatusChoices.ENABLED
 
 

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_enable.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_enable.py
@@ -26,9 +26,8 @@ def test_api_mailboxes__enable_anonymous_forbidden():
     assert models.Mailbox.objects.get().status == enums.MailboxStatusChoices.DISABLED
 
 
-def test_api_mailboxes__enable_authenticated_failure():
-    """Authenticated users should not be able to enable mailbox
-    without specific role on mail domain."""
+def test_api_mailboxes__enable_unrelated_not_found():
+    """Unrelated users should not be able to enable mailbox."""
     user = core_factories.UserFactory()
 
     client = APIClient()
@@ -39,7 +38,7 @@ def test_api_mailboxes__enable_authenticated_failure():
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/enable/",
     )
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert models.Mailbox.objects.get().status == enums.MailboxStatusChoices.DISABLED
 
 

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_list.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_list.py
@@ -25,8 +25,8 @@ def test_api_mailboxes__list_anonymous():
     }
 
 
-def test_api_mailboxes__list_authenticated():
-    """Authenticated users should not be able to list mailboxes"""
+def test_api_mailboxes__list_unrelated_not_found():
+    """Unrelated users should not be able to list mailboxes"""
     user = core_factories.UserFactory()
 
     client = APIClient()
@@ -36,10 +36,8 @@ def test_api_mailboxes__list_authenticated():
     factories.MailboxFactory.create_batch(2, domain=mail_domain)
 
     response = client.get(f"/api/v1.0/mail-domains/{mail_domain.slug}/mailboxes/")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert response.json() == {
-        "detail": "You do not have permission to perform this action."
-    }
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "No MailDomain matches the given query."}
 
 
 @pytest.mark.parametrize(

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_put.py
@@ -35,7 +35,7 @@ def test_api_mailboxes_put__anonymous_forbidden():
     assert mailbox.secondary_email == saved_secondary
 
 
-def test_api_mailboxes_put__unauthorized_forbidden():
+def test_api_mailboxes_put__no_access_forbidden_not_found():
     """Authenticated but unauthoriezd users should not be able to update mailboxes."""
     client = APIClient()
     client.force_login(core_factories.UserFactory())
@@ -49,7 +49,7 @@ def test_api_mailboxes_put__unauthorized_forbidden():
     )
 
     # permission denied at domain level
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     mailbox.refresh_from_db()
     assert mailbox.secondary_email == saved_secondary
 
@@ -68,7 +68,7 @@ def test_api_mailboxes_put__unauthorized_no_mailbox():
 
     # permission denied at domain level
     # the existence of the mailbox is not checked
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_api_mailboxes_put__viewer_forbidden():

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
@@ -28,7 +28,7 @@ def test_api_mailboxes__reset_password_anonymous_unauthorized():
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_api_mailboxes__reset_password_unrelated_forbidden():
+def test_api_mailboxes__reset_password_no_access_forbidden_not_found():
     """Authenticated users not managing the domain
     should not be able to reset its mailboxes password."""
     user = core_factories.UserFactory()
@@ -41,9 +41,9 @@ def test_api_mailboxes__reset_password_unrelated_forbidden():
     response = client.post(
         f"/api/v1.0/mail-domains/{mailbox.domain.slug}/mailboxes/{mailbox.pk}/reset_password/"
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "detail": "No MailDomain matches the given query.",
     }
 
 


### PR DESCRIPTION
## Purpose

Waiting for #974 to be merged.
For confidentiality purposes, when an user has no access to a domain, they are not even allowed to know the domain exists. API should then return a 404 instead of a 403 forbidden.


## Proposal

Description...

- [] item 1...
- [] item 2...
