### PR TITLE
🐛(dimail) ignore oxadmin when importing mailboxes from dimail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🐛(dimail) allow mailboxes and aliases to have the same local part #986
 - 🐛(dimail) ignore oxadmin when importing mailboxes from dimail #986
 - ✨(aliases) delete all aliases in one call #1002
 - ✨(aliases) fix deleting single aliases #1002

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -79,17 +79,6 @@ class MailboxSerializer(serializers.ModelSerializer):
 
         return mailbox
 
-    def validate_local_part(self, value):
-        """Validate this local part does not match a mailbox."""
-        if models.Alias.objects.filter(
-            local_part=value, domain__slug=self.context["domain_slug"]
-        ):
-            raise exceptions.ValidationError(
-                f'Local part "{value}" already used by an alias.'
-            )
-
-        return value
-
 
 class MailboxUpdateSerializer(MailboxSerializer):
     """A more restrictive serializer when updating mailboxes"""
@@ -338,14 +327,3 @@ class AliasSerializer(serializers.ModelSerializer):
             return super().create(validated_data)
 
         return None
-
-    def validate_local_part(self, value):
-        """Validate this local part does not match a mailbox."""
-        if models.Mailbox.objects.filter(
-            local_part=value, domain__slug=self.context["domain_slug"]
-        ).exists():
-            raise exceptions.ValidationError(
-                f'Local part "{value}" already used by a mailbox.'
-            )
-
-        return value

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -394,16 +394,6 @@ class DimailAPIClient:
                 )
                 continue
 
-            if address.username in [
-                alias_.local_part
-                for alias_ in models.Alias.objects.filter(domain=domain)
-            ]:
-                logger.warning(
-                    "%s already used in an existing alias.",
-                    address.username,
-                )
-                continue
-
             if str(address) not in [
                 str(people_mailbox) for people_mailbox in people_mailboxes
             ]:
@@ -842,18 +832,13 @@ class DimailAPIClient:
             (known_alias.local_part, known_alias.destination)
             for known_alias in models.Alias.objects.filter(domain=domain)
         ]
-        known_mailboxes = [
-            known_mailbox.local_part
-            for known_mailbox in models.Mailbox.objects.filter(domain=domain)
-        ]
+
         imported_aliases = []
         for incoming_alias in incoming_aliases:
             if (
                 incoming_alias["username"],
                 incoming_alias["destination"],
-            ) not in known_aliases and incoming_alias[
-                "username"
-            ] not in known_mailboxes:
+            ) not in known_aliases:
                 try:
                     new_alias = models.Alias.objects.create(
                         local_part=incoming_alias["username"],


### PR DESCRIPTION
## Purpose

Ignore oxadmin mailboxes, which are technical addresses not meant for any user. 


EDIT : miiight be obsolete ? I think dimail stopped returning the oxadmin accounts.
EDIT2 : ohohoh nope it did not, let's merge that soon