### PR TITLE
🔒️(security) fix vulnerability due to jaraco.context

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.11"
+          python-version: '3.13'
       - name: Upgrade pip and setuptools
         run: pip install --upgrade pip setuptools
       - name: Install development dependencies

--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Check code formatting with ruff
@@ -281,7 +281,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install development dependencies
         run: pip install --user .[dev]
       - name: Install gettext (required to compile messages)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🔒️(security) upgrade python version to fix vulnerability #1010
 - 🐛(dimail) allow mailboxes and aliases to have the same local part #986
 - 🐛(dimail) ignore oxadmin when importing mailboxes from dimail #986
 - ✨(aliases) delete all aliases in one call #1002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Django People
 
 # ---- base image to inherit from ----
-FROM python:3.12.6-alpine3.20 AS base
+FROM python:3.13.11-alpine AS base
 
 # Upgrade pip to its latest release to speed up dependencies installation
-RUN python -m pip install --upgrade pip setuptools
+RUN python -m pip install --upgrade pip
 
 # Upgrade system packages to install security updates
 RUN apk update && \

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "factory_boy==3.3.3",
     "flower==2.0.1",
     "gunicorn==23.0.0",
+    "jaraco.context>=6.1.0",
     "joserfc==1.3.0",
     "jsonschema==4.25.1",
     "mozilla-django-oidc==4.0.1",


### PR DESCRIPTION
## Purpose

Trivy is failing because of this dependency https://github.com/advisories/GHSA-58pv-8j8x-9vj2

## Proposal

let's upgrade Python and also django-lasuite, because why not
