### PR TITLE
🚸(email) we should ignore case when looking for existing emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- 🚸(email) we should ignore case when looking for existing emails #1056
 - 🏗️(core) migrate from pip to uv
 - ✨(front) add show invitations mails domains access #1040
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -998,7 +998,7 @@ class BaseInvitation(BaseModel):
         super().clean()
 
         # Check if a user already exists for the provided email
-        if User.objects.filter(email=self.email).exists():
+        if User.objects.filter(email__iexact=self.email).exists():
             raise EmailAlreadyKnownException
 
     @property

--- a/src/backend/core/tests/test_models_invitations.py
+++ b/src/backend/core/tests/test_models_invitations.py
@@ -17,6 +17,8 @@ from freezegun import freeze_time
 
 from core import factories, models
 
+from mailbox_manager.exceptions import EmailAlreadyKnownException
+
 pytestmark = pytest.mark.django_db
 
 
@@ -46,6 +48,17 @@ def test_models_invitations_team_required():
     """The "team" field is required."""
     with pytest.raises(exceptions.ValidationError, match="This field cannot be null"):
         factories.InvitationFactory(team=None)
+
+
+def test_models_invitations_email_case_insensitive_duplicate_check():
+    """The email validation should be case-insensitive when checking for existing users."""
+    # Create a user with a lowercase email
+    factories.UserFactory(email="john.doe@example.com")
+
+    # Try to create an invitation with different case
+    # This should raise the same exception as if the email was exactly the same
+    with pytest.raises(EmailAlreadyKnownException):
+        factories.InvitationFactory(email="John.Doe@Example.COM")
 
 
 def test_models_invitations_team_should_be_team_instance():

--- a/src/backend/mailbox_manager/api/client/viewsets.py
+++ b/src/backend/mailbox_manager/api/client/viewsets.py
@@ -419,7 +419,7 @@ class MailDomainInvitationViewset(
         try:
             return super().create(request, *args, **kwargs)
         except EmailAlreadyKnownException as exc:
-            user = models.User.objects.get(email=email)
+            user = models.User.objects.get(email__iexact=email)
 
             models.MailDomainAccess.objects.create(
                 user=user,


### PR DESCRIPTION
## Purpose

Our products mostly rely on email regardless of their case.

Next step would be to normalize email to lower case when storing them in database (or sending them to dimail if not done yet).


## Proposal

- [x] disregard email case when looking for user with specific email address
