### PR TITLE
✅(invitations) test accesses have expected role when created from email

### DIFF
--- a/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
+++ b/src/backend/mailbox_manager/tests/api/invitations/test_api_domain_invitations_create.py
@@ -108,7 +108,9 @@ def test_api_domain_invitations__no_access_forbidden_not_found():
 
 def test_api_domain_invitations__should_not_create_duplicate_invitations():
     """An email should not be invited multiple times to the same domain."""
-    existing_invitation = factories.MailDomainInvitationFactory()
+    existing_invitation = factories.MailDomainInvitationFactory(
+        role=enums.MailDomainRoleChoices.ADMIN
+    )
     domain = existing_invitation.domain
 
     # Grant privileged role on the domain to the user
@@ -124,7 +126,7 @@ def test_api_domain_invitations__should_not_create_duplicate_invitations():
         f"/api/v1.0/mail-domains/{domain.slug}/invitations/",
         {
             "email": existing_invitation.email,
-            "role": "owner",
+            "role": "viewer",
         },
         format="json",
     )
@@ -132,7 +134,8 @@ def test_api_domain_invitations__should_not_create_duplicate_invitations():
     assert response.json()["__all__"] == [
         "Mail domain invitation with this Email address and Domain already exists."
     ]
-    assert models.MailDomainInvitation.objects.count() == 1  # and specifically, not 2
+    invit = models.MailDomainInvitation.objects.get()
+    assert invit.role == existing_invitation.role
 
 
 def test_api_domain_invitations__inviting_known_email_should_create_access():
@@ -157,7 +160,8 @@ def test_api_domain_invitations__inviting_known_email_should_create_access():
     )
 
     assert not models.MailDomainInvitation.objects.exists()
-    assert models.MailDomainAccess.objects.filter(user=existing_user).exists()
+    access = models.MailDomainAccess.objects.get(user=existing_user)
+    assert access.role == "owner"
 
 
 def test_api_domain_invitations__inviting_known_email_case_insensitive():

--- a/src/backend/mailbox_manager/tests/models/test_invitations.py
+++ b/src/backend/mailbox_manager/tests/models/test_invitations.py
@@ -49,10 +49,10 @@ def test_models_domain_invitation__should_convert_invitations_to_accesses_upon_j
 
     # Two invitations to the same mail but to different domains
     email = "future_admin@example.com"
-    invitation_to_domain1 = factories.MailDomainInvitationFactory(
+    invitation_domain1 = factories.MailDomainInvitationFactory(
         email=email, role=enums.MailDomainRoleChoices.OWNER
     )
-    invitation_to_domain2 = factories.MailDomainInvitationFactory(email=email)
+    invitation_domain2 = factories.MailDomainInvitationFactory(email=email)
 
     # an expired invitation that should not be converted
     with freeze_time("1985-10-30"):
@@ -60,31 +60,35 @@ def test_models_domain_invitation__should_convert_invitations_to_accesses_upon_j
 
     # another person invited to domain2
     other_invitation = factories.MailDomainInvitationFactory(
-        domain=invitation_to_domain2.domain
+        domain=invitation_domain2.domain
     )
 
+    # convert
     new_user = core_factories.UserFactory(email=email)
 
-    assert models.MailDomainAccess.objects.filter(
-        domain=invitation_to_domain1.domain, user=new_user
-    ).exists()
-    assert not models.MailDomainInvitation.objects.filter(
-        domain=invitation_to_domain1.domain, email=email
-    ).exists()  # invitation "consumed"
+    invitations = models.MailDomainInvitation.objects.all()
+    accesses = models.MailDomainAccess.objects.all()
 
-    assert models.MailDomainAccess.objects.filter(
-        domain=invitation_to_domain2.domain, user=new_user
+    # invitations 1 and 2 successfully converted
+    access1 = accesses.get(domain=invitation_domain1.domain, user=new_user)
+    assert access1.role == invitation_domain1.role
+    assert not invitations.filter(
+        domain=invitation_domain1.domain, email=email
     ).exists()
-    assert not models.MailDomainInvitation.objects.filter(
-        domain=invitation_to_domain2.domain, email=email
-    ).exists()  # invitation "consumed"
 
-    assert models.MailDomainInvitation.objects.filter(
-        domain=expired_invitation.domain, email=email
-    ).exists()  # expired invitation remains
-    assert models.MailDomainInvitation.objects.filter(
-        domain=invitation_to_domain2.domain, email=other_invitation.email
-    ).exists()  # the other invitation remains
+    access2 = accesses.get(domain=invitation_domain2.domain, user=new_user)
+    assert access2.role == invitation_domain2.role
+    assert not invitations.filter(
+        domain=invitation_domain2.domain, email=email
+    ).exists()
+
+    # expired invitation remains
+    assert invitations.filter(domain=expired_invitation.domain, email=email).exists()
+
+    # the other invitation remains
+    assert invitations.filter(
+        domain=invitation_domain2.domain, email=other_invitation.email
+    ).exists()
 
     log_messages = [msg.message for msg in caplog.records]
     assert (


### PR DESCRIPTION
## Purpose

Trying to catch a bug where accesses created with email sometimes have the wrong role