### PR TITLE
🐛(i18n) fix missing translations for status tag labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🐛(i18n) fix missing translations for status tag labels
+
 ## [1.23.1] - 2026-02-16
 
 - ✨(invitations) refresh expired invitations

--- a/src/frontend/apps/desk/src/components/Tag.tsx
+++ b/src/frontend/apps/desk/src/components/Tag.tsx
@@ -16,6 +16,14 @@ const TagContent = ({ status, showIcon }: TagContentProps) => {
   const { colorsTokens } = useCunninghamTheme();
   const { t } = useTranslation();
 
+  const translatedStatus = {
+    pending: t('pending'),
+    enabled: t('enabled'),
+    disabled: t('disabled'),
+    action_required: t('action required'),
+    failed: t('failed'),
+  };
+
   const textColor = {
     pending: colorsTokens()['info-600'],
     enabled: colorsTokens()['success-600'],
@@ -46,7 +54,7 @@ const TagContent = ({ status, showIcon }: TagContentProps) => {
         text-transform: capitalize;
       `}
     >
-      {t(status).replace('_', ' ')}
+      {translatedStatus[status]}
       {showIcon &&
         (status === 'enabled' ? (
           <Icon


### PR DESCRIPTION
(made with ai, review carefully)
Status labels in the Tag component ("enabled", "action required", etc.) were not translated because `t(status)` used a dynamic variable that i18next-parser cannot extract.

Replace with a static `translations` map using literal `t()` calls so the keys are properly detected during extraction and sent to Crowdin for translation.

