### PR TITLE
📝 Fix documentation and comment typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to
 
 ### Fixed
 
-- 🐛(domains) fix attemps to send invitations to existing users #953
+- 🐛(domains) fix attempts to send invitations to existing users #953
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # People
 
-People is an application to handle users and teams, and distribute permissions accross [La Suite](https://lasuite.numerique.gouv.fr/).
+People is an application to handle users and teams, and distribute permissions across [La Suite](https://lasuite.numerique.gouv.fr/).
 
 It is built on top of [Django Rest
 Framework](https://www.django-rest-framework.org/).

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,7 +1,7 @@
 # What is People?
 
 Space Odyssey is a dynamic organization. They use the People application to enhance teamwork and
-streamline communication among  their co-workers. Let's explore how this application helps them
+streamline communication among their co-workers. Let's explore how this application helps them
 interact efficiently.
 
 Let's see how we could interact with Django's shell to recreate David's environment in the app.
@@ -177,7 +177,7 @@ projectx = Team.objects.create(name="Project X")
 A team can for example be used to create an email alias or to define role based access rights
 (RBAC) in a specific application or all applications of the organization's digital Suite.
 
-Having created he team, Dave is automatically assigned the "owner" role. He invites Ryan,
+Having created the team, Dave is automatically assigned the "owner" role. He invites Ryan,
 granting an "administrator" role to her so she can invite her own colleagues. Both of them can
 then proceed to invite other colleagues as simple members. If Ryan wants, she can upgrade a
 colleague to "administrator" but only David can upgrade someone to the "owner" status:

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -874,7 +874,7 @@ class TeamAccess(BaseModel):
 
     def delete(self, *args, **kwargs):
         """
-        Override delete method to fire webhooks on  to team accesses.
+        Override delete method to fire webhooks on to team accesses.
         Don't allow deleting a team access until it is successfully synchronized with all
         its webhooks.
         """

--- a/src/backend/core/tests/fixtures/matrix.py
+++ b/src/backend/core/tests/fixtures/matrix.py
@@ -78,7 +78,7 @@ def mock_join_room_forbidden():
 
 # INVITE USER
 def mock_invite_successful():
-    """Mock response when invite request was succesful. Does not check the user exists."""
+    """Mock response when invite request was successful. Does not check the user exists."""
     return {"message": {}, "status_code": status.HTTP_200_OK}
 
 

--- a/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
+++ b/src/backend/mailbox_manager/management/commands/setup_dimail_db.py
@@ -1,4 +1,4 @@
-"""Management command creating a  dimail-api container, for test purposes."""
+"""Management command creating a dimail-api container, for test purposes."""
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_retrieve.py
@@ -33,7 +33,7 @@ def test_api_mail_domains__retrieve_anonymous():
 @responses.activate
 def test_api_domains__retrieve_non_existing():
     """
-    Authenticated users should have an explicit error when trying to retrive
+    Authenticated users should have an explicit error when trying to retrieve
     a domain that doesn't exist.
     """
     client = APIClient()

--- a/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_list.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain_accesses/test_api_mail_domain_accesses_list.py
@@ -199,7 +199,7 @@ def test_api_mail_domain__accesses_list_authenticated_constant_numqueries(
 
 
 def test_api_mail_domain__accesses_list_authenticated_ordering():
-    """MailDomain  accesses can be ordered by "role"."""
+    """MailDomain accesses can be ordered by "role"."""
 
     user = core_factories.UserFactory()
     mail_domain = factories.MailDomainFactory()


### PR DESCRIPTION
## Summary
- Fix 9 typos in documentation and code comments

## Details
- README.md: accross → across
- CHANGELOG.md: attemps → attempts
- docs/models.md: "among  their" → "among their", "he team" → "the team"
- test_api_mail_domains_retrieve.py: retrive → retrieve
- matrix.py: succesful → successful
- setup_dimail_db.py: "a  dimail" → "a dimail"
- models.py: "on  to" → "on to"
- test_api_mail_domain_accesses_list.py: "MailDomain  accesses" → "MailDomain accesses"

## Test plan
- [ ] Verify changes are correct
- [ ] CI passes