### PR TITLE
🚸(mailboxes) improve error message when no secondary email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(dimail) fix no import for functional mailboxes
+- 🚸(mailboxes) improve error message when no secondary email
 
 ## [1.24.0] - 2026-03-24
 

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_reset_password.py
@@ -75,8 +75,7 @@ def test_api_mailboxes__reset_password_no_secondary_email():
     client = APIClient()
     client.force_login(access.user)
 
-    error = "Password reset requires a secondary email address. \
-Please add a valid secondary email before trying again."
+    error = "Please add a secondary email before resetting the password."
 
     # Mailbox with no secondary email
     mailbox = factories.MailboxEnabledFactory(domain=mail_domain, secondary_email=None)

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -652,7 +652,7 @@ class DimailAPIClient:
         """Send a request to reset mailbox password."""
         if not mailbox.secondary_email or mailbox.secondary_email == str(mailbox):
             raise exceptions.ValidationError(
-                "Password reset requires a secondary email address. Please add a valid secondary email before trying again."
+                _("Please add a secondary email before resetting the password.")
             )
 
         try:

--- a/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/panel/PanelActions.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/mailboxes/components/panel/PanelActions.tsx
@@ -67,7 +67,11 @@ export const PanelActions = ({ mailDomain, mailbox }: PanelActionsProps) => {
       {
         onSuccess: () =>
           toast(t('Successfully reset password.'), VariantType.SUCCESS),
-        onError: () => toast(t('Failed to reset password'), VariantType.ERROR),
+        onError: (error) =>
+          toast(
+            t(error.cause?.[0] || 'Failed to reset password'),
+            VariantType.ERROR,
+          ),
       },
     );
   };


### PR DESCRIPTION
## Purpose

improve error message when trying to reset password on a mailbox not having a secondary email.
Fixes #1080 