### PR TITLE
(i18n) Update no alias message in AliasesListView

### DIFF
--- a/src/frontend/apps/desk/src/features/mail-domains/aliases/components/panel/AliasesListView.tsx
+++ b/src/frontend/apps/desk/src/features/mail-domains/aliases/components/panel/AliasesListView.tsx
@@ -143,7 +143,7 @@ export function AliasesListView({
       {!filteredAliases.length && (
         <Box $align="center" $margin={{ top: 'base', bottom: 'base' }}>
           <Text $size="small">
-            {t('No alias was created with this mail domain.')}
+            {t('No alias found.')}
           </Text>
         </Box>
       )}

--- a/src/frontend/apps/desk/src/i18n/translations.json
+++ b/src/frontend/apps/desk/src/i18n/translations.json
@@ -193,7 +193,7 @@
       "New group": "Nouveau groupe",
       "New mail address": "Nouvelle adresse mail",
       "New name...": "Nouveau nom...",
-      "No alias was created with this mail domain.": "Aucun alias n'a été créée avec ce nom de domaine.",
+      "No alias found.": "Aucun alias n'a été trouvé.",
       "No domains exist.": "Aucun domaine existant.",
       "No mail box was created with this mail domain.": "Aucune boîte mail n'a été créée avec ce nom de domaine.",
       "No teams exist.": "Aucune équipe n'existe.",


### PR DESCRIPTION
## Purpose

Current message is misleading when searching

<img width="1124" height="218" alt="Capture d’écran 2026-04-13 à 12 25 46" src="https://github.com/user-attachments/assets/08f8e671-081a-4998-9acc-a7eddece3dd1" />


## Proposal

Change the wording
