### PR TITLE
🐛(dimail) fix login code sent to wrong dimail url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- 🐛(dimail) fix login code sent to wrong dimail url
+
+
 ## [1.25.0] - 2026-04-20
 
 ### Added

--- a/src/backend/mailbox_manager/api/client/serializers.py
+++ b/src/backend/mailbox_manager/api/client/serializers.py
@@ -72,7 +72,7 @@ class MailboxSerializer(serializers.ModelSerializer):
                 )
             else:
                 mailbox_data["link"] = (
-                    f"{client.API_URL}/code/{client.get_login_code(mailbox)}"
+                    f"{settings.WEBMAIL_URL}/code/{client.get_login_code(mailbox)}"
                 )
 
                 if not settings.SEND_MAILBOX_PASSWORD:

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_send_link.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_send_link.py
@@ -6,6 +6,7 @@ import logging
 from unittest import mock
 
 from django.conf import settings
+from django.test import override_settings
 
 import pytest
 import responses
@@ -113,9 +114,9 @@ Please add a valid secondary email before trying again."
         enums.MailDomainRoleChoices.OWNER,
         enums.MailDomainRoleChoices.ADMIN,
     ],
-    "",
 )
 @responses.activate
+@override_settings(WEBMAIL_URL="https://webmail.fr")
 def test_api_mailboxes__login_link_admin_successful(role, dimail_token_ok, caplog):  # pylint: disable=W0613
     """Owner and admin users should be able to request login link for any mailboxes.
     Login links should be sent to secondary email."""
@@ -134,10 +135,9 @@ def test_api_mailboxes__login_link_admin_successful(role, dimail_token_ok, caplo
 
     assert mock_send.call_count == 1
     assert "Here is your login link" in mock_send.mock_calls[0][1][1]
-    assert "http://dimail:8000/code/OneTimeCode" in mock_send.mock_calls[0][1][1]
+    assert "https://webmail.fr/code/OneTimeCode" in mock_send.mock_calls[0][1][1]
     assert mailbox.password not in mock_send.mock_calls[0][1][1]
     assert mock_send.mock_calls[0][1][3][0] == mailbox.secondary_email
-
     assert response.status_code == status.HTTP_200_OK
 
 

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -322,7 +322,7 @@ class DimailAPIClient:
         template_name = "send_login_link"
         recipient = mailbox.secondary_email
 
-        login_link = f"{self.API_URL}/code/{self.get_login_code(mailbox)}"
+        login_link = f"{settings.WEBMAIL_URL}/code/{self.get_login_code(mailbox)}"
         self._send_mailbox_related_email(
             title,
             template_name,


### PR DESCRIPTION
## Purpose

Login code was mistakenly sent to API_URL. Modify client method to send code to WEBMAIL_URL instead.

## Proposal

Description...

- [x] modify called URL in dimail client
- [x] update related tests
