### PR TITLE
🐛(dimail) fix trailing slash

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -68,4 +68,5 @@ MbyqKyC6DAzv4jEEhHaN7oY=
 "
 
 # INTEROP
+WEBMAIL_URL = "https://webmail.fr"
 MAIL_PROVISIONING_API_CREDENTIALS="bGFfcmVnaWU6cGFzc3dvcmQ=" # Dev and test key for dimail interop

--- a/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_send_link.py
+++ b/src/backend/mailbox_manager/tests/api/mailboxes/test_api_mailboxes_send_link.py
@@ -171,7 +171,7 @@ def test_api_mailboxes__login_link_connexion_failed(dimail_token_ok):  # pylint:
     # token response in fixtures
     responses.add(
         responses.POST,
-        f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/code/",
+        f"{dimail_url}/domains/{mail_domain.name}/mailboxes/{mailbox.local_part}/code",
         body=ConnectionError(),
     )
 

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -386,7 +386,7 @@ class DimailAPIClient:
 
         try:
             response = session.post(
-                f"{self.API_URL}/domains/{mailbox.domain.name}/mailboxes/{mailbox.local_part}/code/",
+                f"{self.API_URL}/domains/{mailbox.domain.name}/mailboxes/{mailbox.local_part}/code",
                 json={"expires_in": 3600, "maxuse": 1},
                 headers=self._get_headers(),
                 verify=True,


### PR DESCRIPTION
## Purpose

Trailing slash are the worst. This caused dimail api to fail miserably.


## Proposal

Description...

- [] item 1...
- [] item 2...
