### PR TITLE
Mpj/fix trailing slashes on fix endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(dimail) fix trailing slashes on dimail spec and fix endpoint
 - 🐛(dimail) fix trailing slash on dimail check endpoint
 
 ## [1.25.4] - 2026-05-13

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_create.py
@@ -90,7 +90,7 @@ def test_api_mail_domains__create_authenticated():
     )
     responses.add(
         responses.GET,
-        re.compile(rf".*/domains/{domain_name}/spec/"),
+        re.compile(rf".*/domains/{domain_name}/spec"),
         body=json.dumps(DOMAIN_SPEC),
         status=status.HTTP_200_OK,
         content_type="application/json",
@@ -177,7 +177,7 @@ def test_api_mail_domains__create_dimail_domain(caplog):
     )
     responses.add(
         responses.GET,
-        re.compile(rf".*/domains/{domain_name}/spec/"),
+        re.compile(rf".*/domains/{domain_name}/spec"),
         body=json.dumps(DOMAIN_SPEC),
         status=status.HTTP_200_OK,
         content_type="application/json",

--- a/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_fetch.py
+++ b/src/backend/mailbox_manager/tests/api/mail_domain/test_api_mail_domains_fetch.py
@@ -111,7 +111,7 @@ def test_api_mail_domains__fetch_from_dimail_admin_successful(role):
     )
     responses.add(
         responses.GET,
-        re.compile(rf".*/domains/{domain.name}/spec/"),
+        re.compile(rf".*/domains/{domain.name}/spec"),
         json=dimail_fixtures.DOMAIN_SPEC,
         status=200,
     )

--- a/src/backend/mailbox_manager/tests/test_admin_actions.py
+++ b/src/backend/mailbox_manager/tests/test_admin_actions.py
@@ -170,7 +170,7 @@ def test_fetch_domain_expected_config(client, domain_status):
     }
     responses.add(
         responses.GET,
-        re.compile(rf".*/domains/{domain.name}/spec/"),
+        re.compile(rf".*/domains/{domain.name}/spec"),
         body=json.dumps(DOMAIN_SPEC),
         status=status.HTTP_200_OK,
         content_type="application/json",

--- a/src/backend/mailbox_manager/tests/test_tasks.py
+++ b/src/backend/mailbox_manager/tests/test_tasks.py
@@ -73,7 +73,7 @@ def test_fetch_domain_status_task_success():  # pylint: disable=too-many-locals
     # domain_enabled2 is broken with internal error, we try to fix it
     responses.add(
         responses.GET,
-        re.compile(rf".*/domains/{domain_enabled2.name}/fix/"),
+        re.compile(rf".*/domains/{domain_enabled2.name}/fix"),
         body=json.dumps(body_content_broken_internal),
         status=200,
         content_type="application/json",

--- a/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
+++ b/src/backend/mailbox_manager/tests/test_utils_dimail_client.py
@@ -368,7 +368,7 @@ def test_dimail__fetch_domain_status__switch_to_failed(domain_status):
     )
     # the endpoint fix is called and still returns KO for internal checks
     responses.get(
-        re.compile(rf".*/domains/{domain.name}/fix/"),
+        re.compile(rf".*/domains/{domain.name}/fix"),
         json=body_domain_broken,
         status=status.HTTP_200_OK,
         content_type="application/json",
@@ -424,7 +424,7 @@ def test_dimail__fetch_domain_status__full_fix_scenario(domain_status):
     body_domain_ok = CHECK_DOMAIN_OK.copy()
     body_domain_ok["name"] = domain.name
     responses.get(
-        re.compile(rf".*/domains/{domain.name}/fix/"),
+        re.compile(rf".*/domains/{domain.name}/fix"),
         json=body_domain_ok,
         status=status.HTTP_200_OK,
         content_type="application/json",

--- a/src/backend/mailbox_manager/utils/dimail.py
+++ b/src/backend/mailbox_manager/utils/dimail.py
@@ -586,7 +586,7 @@ class DimailAPIClient:
         """Send a request to dimail to fix a domain.
         Allow to fix internal checks."""
         response = session.get(
-            f"{self.API_URL}/domains/{domain.name}/fix/",
+            f"{self.API_URL}/domains/{domain.name}/fix",
             headers={"Authorization": f"Basic {self.API_CREDENTIALS}"},
             verify=True,
             timeout=self.API_TIMEOUT,
@@ -672,7 +672,7 @@ class DimailAPIClient:
         """Send a request to dimail to get domain specification for DNS configuration."""
         try:
             response = session.get(
-                f"{self.API_URL}/domains/{domain.name}/spec/",
+                f"{self.API_URL}/domains/{domain.name}/spec",
                 headers={"Authorization": f"Basic {self.API_CREDENTIALS}"},
                 verify=True,
                 timeout=self.API_TIMEOUT,


### PR DESCRIPTION
## Purpose

Remove trailing slashes on `fix` and `spec` endpoints to fix broken redirects.
Going to fix on dimail's side too to fix redirects.

## Proposal

Description...

- [] item 1...
- [] item 2...
